### PR TITLE
Refresh Persona starter kit

### DIFF
--- a/.agent/persona/SKILL.md
+++ b/.agent/persona/SKILL.md
@@ -7,6 +7,13 @@ description: AI assistant framework for building unique, authentic portfolio web
 
 You are an AI assistant helping users build a unique portfolio website from scratch.
 
+## Maintainer Mode
+
+If the user is updating Persona itself (for example its README, setup script,
+dependencies, tests, workflows, or starter experience), treat the repository as a
+product being maintained. Inspect and update the starter kit; do not start the
+portfolio-building workflow or assume the maintainer is creating their own site.
+
 **This is NOT a template.** You build from a blank canvas based on who the user is.
 
 ---

--- a/.agent/skills/deploy/SKILL.md
+++ b/.agent/skills/deploy/SKILL.md
@@ -1,369 +1,73 @@
 ---
 name: deploy
-description: Help users deploy their portfolio to production. Covers Vercel, Netlify, Cloudflare Pages, GitHub Pages, Docker, and MCP integration for AI-driven deployment.
+description: Publish a completed Persona portfolio safely through Vercel or GitHub Pages.
 ---
 
-# Skill: Deployment
+# Deploy a Persona portfolio
 
-Help users deploy their portfolio to production.
+Use this only after the portfolio is complete. Never publish the untouched Persona starter page.
 
----
+## Preflight
 
-## Quick Deploy
+1. Run `git remote -v`. Do not publish to `JacbK/Persona`.
+2. Run `npm run check` and fix every failure.
+3. Check mobile layout, links, images, metadata, favicon, and social preview.
+4. Search for placeholders and private material:
 
-Ask your AI assistant:
-> "Deploy my portfolio to Vercel"
-
-The assistant can run CLI commands (`vercel`, `netlify`, `gh`) to deploy for you.
-
----
-
-## Pre-Deployment Checklist
-
-Before deploying, verify:
-
-- [ ] `npm run build` succeeds with no errors
-- [ ] All images moved to `/public` and paths updated
-- [ ] Environment variables documented (if any)
-- [ ] Links are valid (GitHub, LinkedIn, project URLs)
-- [ ] No placeholder content ("Lorem ipsum", "TODO", etc.)
-- [ ] Responsive design works on mobile
-- [ ] Favicon and meta tags set
-
----
-
-## Deployment Options
-
-### 1. Vercel (Recommended)
-
-**Why**: Zero-config for Next.js, free tier, automatic HTTPS, preview deployments.
-
-**Steps**:
 ```bash
-# Install Vercel CLI
-npm i -g vercel
+rg -n "TODO|Lorem ipsum|Your Name" src public
+git status --short
+```
 
-# Deploy (first time - will prompt for setup)
+5. Confirm that `profile.yaml`, resumes, and uploaded materials are safe to make public.
+
+## Ask before publishing
+
+Offer:
+
+- Vercel — recommended for Next.js.
+- GitHub Pages — free static hosting.
+- Not now.
+
+Publishing changes external state, so wait for the user's choice.
+
+## Vercel
+
+The simplest path is Vercel's Git integration:
+
+1. Push the portfolio to the user's own GitHub repository.
+2. Import that repository at `https://vercel.com/new`.
+3. Keep the detected Next.js settings.
+4. Deploy and verify the live URL.
+
+For CLI deployment, use the user's installed and authenticated Vercel CLI. Do not request, print, or store a token in project files.
+
+```bash
 vercel
-
-# Deploy to production
 vercel --prod
 ```
 
-**Or via GitHub**:
-1. Push to GitHub
-2. Go to vercel.com
-3. Import repository
-4. Vercel auto-detects Next.js settings
-5. Click Deploy
+The included `.github/workflows/deploy-vercel.yml` is manual. It requires `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` repository secrets.
 
-**Custom Domain**:
-```bash
-# Add domain in Vercel dashboard, then:
-vercel domains add yourdomain.com
-```
+## GitHub Pages
 
----
+GitHub Pages needs a static export. Persona's manual workflow handles this in a disposable CI checkout:
 
-### 2. Netlify
+1. Push to the user's own GitHub repository.
+2. In repository Settings → Pages, choose GitHub Actions.
+3. Run **Deploy portfolio to GitHub Pages** from the Actions tab.
+4. Verify the Pages URL, including images and internal links.
 
-**Steps**:
-```bash
-# Install Netlify CLI
-npm i -g netlify-cli
+The workflow removes the local-only config UI and APIs only from its temporary build workspace. Do not delete working source files just to deploy.
 
-# Build first
-npm run build
+## Other hosts
 
-# Deploy
-netlify deploy --prod --dir=.next
-```
+Use the host's current official Next.js adapter or documentation. Do not guess output directories; Next.js server and static-export deployments use different outputs.
 
-**Or via GitHub**:
-1. Push to GitHub
-2. Go to netlify.com
-3. "New site from Git"
-4. Build command: `npm run build`
-5. Publish directory: `.next`
+## Safety rules
 
----
-
-### 3. Cloudflare Pages
-
-**Steps**:
-1. Push to GitHub
-2. Go to Cloudflare Pages dashboard
-3. Connect repository
-4. Build settings:
-   - Framework: Next.js
-   - Build command: `npm run build`
-   - Output: `.next`
-
----
-
-### 4. GitHub Pages (Static Export)
-
-**Note**: Requires static export, no server features.
-
-**CRITICAL PRE-FLIGHT**:
-1. **Check Remote**: Run `git remote -v`. If it points to `JacbK/persona` (the template), **REMOVE IT**.
-2. **Clean API**: Static export fails if `/api` routes exist. Run `rm -rf src/app/api src/app/config`.
-
-**Steps**:
-
-1. **Prepare Repo**:
-```bash
-# 1. Remove template remote (if exists)
-git remote remove origin
-
-# 2. Create NEW repository (replace 'my-portfolio' with your name)
-gh repo create my-portfolio --public --source=. --push
-```
-
-2. **Configure `next.config.ts`**:
-```typescript
-const nextConfig = {
-  output: 'export',
-  images: { unoptimized: true },
-  // REQUIRED: match your repo name if not a user site
-  basePath: '/my-portfolio', 
-};
-```
-
-3. **Build & Push**:
-```bash
-# Clean incompatible files
-rm -rf src/app/api src/app/config
-
-# Build locally to verify
-npm run build
-
-# Push
-git add .
-git commit -m "chore: prepare for static deployment"
-git push -u origin main
-```
-
-4. **Enable Pages**:
-   - Settings → Pages → Source: GitHub Actions
-
----
-
-### 5. Self-Hosted (Docker)
-
-**Dockerfile**:
-```dockerfile
-FROM node:20-alpine AS builder
-WORKDIR /app
-COPY package*.json ./
-RUN npm ci
-COPY . .
-RUN npm run build
-
-FROM node:20-alpine AS runner
-WORKDIR /app
-ENV NODE_ENV=production
-COPY --from=builder /app/.next/standalone ./
-COPY --from=builder /app/.next/static ./.next/static
-COPY --from=builder /app/public ./public
-EXPOSE 3000
-CMD ["node", "server.js"]
-```
-
-**Run**:
-```bash
-docker build -t portfolio .
-docker run -p 3000:3000 portfolio
-```
-
----
-
-## Environment Variables
-
-If using environment variables:
-
-1. **Local**: Create `.env.local`
-2. **Vercel**: Add in Project Settings → Environment Variables
-3. **Netlify**: Add in Site Settings → Environment
-4. **Docker**: Pass with `-e` or use `.env` file
-
----
-
-## Custom Domain Setup
-
-### General Steps
-1. Add domain in hosting provider
-2. Update DNS records:
-   - A record: Points to hosting IP
-   - CNAME: Points to hosting subdomain
-3. Wait for DNS propagation (up to 48h, usually minutes)
-4. SSL certificate auto-provisions
-
-### Common Providers
-- **Vercel**: Automatic SSL, add domain in dashboard
-- **Netlify**: Automatic SSL, add domain in dashboard
-- **Cloudflare**: Automatic SSL + CDN
-
----
-
-## Post-Deployment
-
-After deploying:
-
-1. **Test the live site**
-   - Check all pages load
-   - Test on mobile
-   - Verify images load
-   - Click all links
-
-2. **Set up analytics** (optional)
-   - Vercel Analytics (built-in)
-   - Plausible (privacy-focused)
-   - Google Analytics
-
-3. **Submit to search engines** (optional)
-   - Google Search Console
-   - Bing Webmaster Tools
-
----
-
-## Troubleshooting
-
-### Build Fails
-- Check `npm run build` locally first
-- Review error messages for missing dependencies
-- Ensure all imports are valid
-
-### Images Not Loading
-- Move to `/public` folder
-- Use absolute paths: `/images/photo.jpg`
-- Check case sensitivity (Linux is case-sensitive)
-
-### 404 on Routes
-- For static export: ensure `generateStaticParams` for dynamic routes
-- Check `next.config.ts` for `trailingSlash` setting
-
-### Slow Performance
-- Run Lighthouse audit
-- Optimize images (use `next/image`)
-- Check for large bundle sizes
-
----
-
-## CI/CD with GitHub Actions
-
-Pre-configured workflows in `.github/workflows/`:
-
-### Vercel (deploy-vercel.yml)
-Auto-deploy on push to main. Setup:
-1. Import repo at vercel.com
-2. Run `vercel link` locally to get IDs
-3. Add GitHub secrets:
-   - `VERCEL_TOKEN` (from vercel.com/account/tokens)
-   - `VERCEL_ORG_ID`
-   - `VERCEL_PROJECT_ID`
-
-### GitHub Pages (deploy-pages.yml)
-Static export to GitHub Pages. Setup:
-1. Enable in repo Settings → Pages → Source: GitHub Actions
-2. Ensure `next.config.ts` has `output: 'export'`
-
----
-
-## MCP Integration
-
-MCP (Model Context Protocol) enables AI-driven deployment. Supported by Claude Code, Codex, and Gemini CLI.
-
-**Setup:** Run `./bin/setup.sh` and select "Yes" when asked about deployment integration.
-
-### Manual Setup by CLI
-
-#### Claude Code
-```bash
-claude mcp add github -e GITHUB_PERSONAL_ACCESS_TOKEN="your-token" -- npx -y @modelcontextprotocol/server-github
-claude mcp add vercel -e VERCEL_API_TOKEN="your-token" -- npx -y vercel-mcp-server
-```
-
-#### Codex
-```bash
-codex mcp add github -- npx -y @modelcontextprotocol/server-github
-codex mcp add vercel -- npx -y vercel-mcp-server
-```
-Then set environment variables: `GITHUB_PERSONAL_ACCESS_TOKEN`, `VERCEL_API_TOKEN`
-
-#### Gemini CLI
-Add to `~/.gemini/settings.json`:
-```json
-{
-  "mcpServers": {
-    "github": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-github"],
-      "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "your-token" }
-    },
-    "vercel": {
-      "command": "npx",
-      "args": ["-y", "vercel-mcp-server"],
-      "env": { "VERCEL_API_TOKEN": "your-token" }
-    }
-  }
-}
-```
-
-### Get Tokens
-
-- **GitHub:** https://github.com/settings/tokens (scopes: `repo`, `read:user`)
-- **Vercel:** https://vercel.com/account/tokens
-
-### Usage
-
-Once configured, just ask your AI assistant:
-- "Deploy my portfolio to Vercel"
-- "Create a GitHub repo and deploy to GitHub Pages"
-
----
-
-## Shell Commands (All CLIs)
-
-Any AI assistant can deploy using standard CLI tools (no MCP required).
-
-### GitHub Pages via `gh` CLI
-
-**First, ensure you have your own repo** (not the template):
-```bash
-# Check current remote
-git remote -v
-
-# If it points to the template repo, remove it and create your own:
-git remote remove origin
-gh repo create my-portfolio --public --source=. --push
-```
-
-**Then enable GitHub Pages**:
-```bash
-# Enable GitHub Pages with Actions
-gh api repos/{owner}/{repo}/pages -X POST -f build_type=workflow
-```
-
-Requires:
-1. `gh` CLI installed and authenticated (`gh auth login`)
-2. Your own GitHub repository (not the template)
-3. Static export in `next.config.ts`:
-   ```typescript
-   output: 'export',
-   images: { unoptimized: true }
-   ```
-
-### Vercel via CLI
-
-```bash
-npm i -g vercel
-vercel --prod
-```
-
-### Netlify via CLI
-
-```bash
-npm i -g netlify-cli
-netlify deploy --prod
-```
+- Never deploy while `origin` points to the Persona template repository.
+- Never put access tokens in `profile.yaml`, source files, shell history, or agent configuration committed to Git.
+- Do not edit global agent or MCP settings as part of deployment.
+- Keep deployment workflows manual until the user deliberately enables automatic production deploys.
+- After publishing, test the real URL on desktop and mobile.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: Check starter kit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      - run: npm run check
+      - run: npm run audit

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,17 +1,8 @@
-# Deploy to GitHub Pages (static export)
-#
-# Setup:
-# 1. Go to repo Settings → Pages
-# 2. Source: GitHub Actions
-# 3. Ensure next.config.ts has: output: 'export'
-#
-# Note: This uses static export, so no server features (API routes, etc.)
+name: Deploy portfolio to GitHub Pages
 
-name: Deploy to GitHub Pages
-
+# Manual by design: creating a repository from the Persona template should not
+# publish the starter page automatically.
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -20,31 +11,27 @@ permissions:
   id-token: write
 
 concurrency:
-  group: 'pages'
+  group: pages
   cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      - name: Remove local-only setup tools from the disposable build workspace
+        run: rm -rf src/app/api src/app/config
+      - name: Build static site
         run: npm run build
         env:
+          PERSONA_STATIC_EXPORT: 'true'
           GITHUB_PAGES_BASE_PATH: /${{ github.event.repository.name }}
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: ./out
 
@@ -55,6 +42,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Deploy to GitHub Pages
+      - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -1,20 +1,11 @@
-# Deploy to Vercel on push to main
-#
-# Setup:
-# 1. Go to https://vercel.com and import your repo
-# 2. Get your Vercel token: https://vercel.com/account/tokens
-# 3. Run: vercel link (to get org and project IDs)
-# 4. Add these secrets in GitHub repo Settings → Secrets:
-#    - VERCEL_TOKEN
-#    - VERCEL_ORG_ID
-#    - VERCEL_PROJECT_ID
+name: Deploy portfolio to Vercel
 
-name: Deploy to Vercel
-
+# Manual by design: add the three repository secrets, then run this workflow.
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -24,22 +15,22 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install Vercel CLI
-        run: npm install -g vercel
-
-      - name: Pull Vercel Environment
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      - name: Check Vercel secrets
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          test -n "$VERCEL_TOKEN"
+          test -n "$VERCEL_ORG_ID"
+          test -n "$VERCEL_PROJECT_ID"
+      - name: Pull Vercel environment
+        run: npx --yes vercel@56.3.2 pull --yes --environment=production --token="${{ secrets.VERCEL_TOKEN }}"
       - name: Build
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-
+        run: npx --yes vercel@56.3.2 build --prod --token="${{ secrets.VERCEL_TOKEN }}"
       - name: Deploy
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: npx --yes vercel@56.3.2 deploy --prebuilt --prod --token="${{ secrets.VERCEL_TOKEN }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,3 +10,7 @@ This file contains:
 - Quality standards and checklists
 
 Start by reading that file, then follow the workflow.
+
+If the user asks to improve Persona itself—its setup, documentation, dependencies,
+tests, workflows, or starter experience—work as the starter-kit maintainer. Do not
+assume they are currently building a personal portfolio.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jacob Kieser
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,106 +1,79 @@
 # Persona
 
-**Build your portfolio website with AI.**
+**Build a portfolio that feels like you—not a template with your name pasted in.**
 
-Persona is a drop-in kit for AI coding assistants that helps you create a unique, professional portfolio site. No templates—the AI researches who you are and builds something custom.
+Persona is a starter kit for AI coding agents. You share your goals, work, and visual taste in a local setup page. Your agent uses that context to research, propose a design, build the site, and help you publish it.
 
-<img width="2366" height="1196" alt="Persona Setup UI" src="https://github.com/user-attachments/assets/e25a8419-4892-488d-9795-c7d25ee85728" />
+<img width="2366" height="1196" alt="Persona's local setup page" src="https://github.com/user-attachments/assets/e25a8419-4892-488d-9795-c7d25ee85728" />
 
-## Supported AI Assistants
+## Start here
 
-| Assistant | Auto-Discovery | File |
-|-----------|---------------|------|
-| [Claude Code](https://claude.ai/code) | ✓ | `CLAUDE.md` |
-| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | ✓ | `GEMINI.md` |
-| [Codex](https://openai.com/codex) | ✓ | `AGENTS.md` |
-| [Cursor](https://cursor.sh) | ✓ | `.cursorrules` |
-| [Antigravity](https://antigravity.google) | ✓ | `.antigravity/rules.md` |
-| [Windsurf](https://windsurf.com) | Manual | — |
-| Others (Aider, etc.) | Manual | — |
-
-## Quick Start
+1. [Create a repository from this template](https://github.com/new?template_name=persona&template_owner=JacbK).
+2. Clone your new repository.
+3. Run:
 
 ```bash
-git clone https://github.com/JacbK/persona.git
-cd persona
 ./setup.sh
 ```
 
-The setup script walks you through:
+Persona opens a local setup page, saves your answers to `profile.yaml`, and then opens the coding agent you choose.
 
-1. **Repository** — Creates your own GitHub repo
-2. **Dependencies** — Installs packages
-3. **Configuration** — Opens a UI to set your preferences
-4. **AI Assistant** — Selects and configures your coding AI
-5. **Launch** — AI starts building your portfolio
+Requirements: Node.js 20.18 or newer, npm, Git, and a coding agent.
 
-## Requirements
+## What Persona does
 
-- Node.js 18+
-- An AI coding assistant (see supported list above)
+- Learns who you are from your profile and optional materials.
+- Researches only when you and your agent choose to.
+- Proposes a visual direction before changing the site.
+- Builds a custom Next.js portfolio instead of filling a fixed template.
+- Checks the result before helping you publish it.
 
-## How It Works
+## Supported coding agents
 
-1. **You configure** — Run `./setup.sh` to set your name, links, sections, and design preferences
-2. **You upload** (optional) — Drop your resume, headshot, or project screenshots in `/materials`
-3. **AI researches** — The agent reads your config, materials, GitHub, and searches the web
-4. **AI designs** — Creates a unique visual direction and presents it for approval
-5. **AI builds** — Writes React/Tailwind code from scratch
-6. **You deploy** — One command to go live on Vercel, Netlify, or GitHub Pages
+Persona includes auto-discovered instructions for Claude Code, Gemini CLI, Codex, Cursor, and Antigravity. Windsurf and other agents can read `.agent/persona/SKILL.md` directly.
 
-The result isn't a filled-in template—it's a custom site that reflects who you actually are.
+Persona does not install agents, edit global agent settings, or ask for access tokens. Install and sign in to your chosen agent through its official instructions.
 
-## Recommended Models
+## Your data stays local
 
-For best results, use the most capable model available:
+The setup page runs at `127.0.0.1` and is disabled in production builds. Your profile and uploaded materials are written into your repository. Persona does not send them anywhere by itself.
 
-| CLI | Recommended Model |
-|-----|------------------|
-| Claude Code | Opus 4.5 |
-| Gemini CLI | Gemini 3 Pro |
-| Codex | GPT-5.2-Codex |
-| Cursor | Claude Opus 4.5 |
-| Antigravity | Gemini 3 Pro |
+Anything committed or pushed to a public repository becomes public. Review `profile.yaml` and `materials/` before publishing.
 
-## After Setup
-
-Talk to your AI assistant naturally:
-
-- *"Add my new project X"*
-- *"Update my work experience"*
-- *"Make the hero section more bold"*
-- *"Deploy to Vercel"*
-
-Run `./setup.sh` again anytime to edit your config.
-
-## Deploy
-
-Ask your AI, or run directly:
+## Useful commands
 
 ```bash
-vercel --prod      # Vercel (recommended)
-netlify deploy     # Netlify
+npm run dev          # Open the local site
+npm run check        # Lint, type-check, test, check setup, and build
+npm run build        # Make a production build
+./setup.sh            # Create or edit your profile
 ```
 
-GitHub Actions workflows are pre-configured in `.github/workflows/`.
+## Publishing
 
-## Project Structure
+Vercel is the simplest option: import your repository in Vercel and deploy it as a Next.js project.
 
-```
+The included GitHub Actions deployments are manual on purpose, so a fresh template does not fail or publish unexpectedly. See `.agent/skills/deploy/SKILL.md` for Vercel and GitHub Pages steps.
+
+## Project structure
+
+```text
 persona/
-├── .agent/                    # AI instructions (Agent Skills standard)
-│   ├── persona/SKILL.md       # Main instructions
-│   └── skills/                # Specialized skills
-├── CLAUDE.md                  # Claude Code auto-discovery
-├── GEMINI.md                  # Gemini CLI auto-discovery
-├── AGENTS.md                  # Codex auto-discovery
-├── .cursorrules               # Cursor auto-discovery
-├── .antigravity/rules.md      # Antigravity auto-discovery
-├── materials/                 # Your resume, images, etc.
-├── profile.yaml               # Your configuration (created by setup)
-└── src/                       # Next.js app (AI builds here)
+├── .agent/           # Shared workflow and design guidance
+├── materials/        # Optional resume, images, and project material
+├── src/app/          # Next.js site and local setup page
+├── src/lib/          # Config, upload, and safety helpers
+├── AGENTS.md         # Codex instructions
+├── CLAUDE.md         # Claude Code instructions
+├── GEMINI.md         # Gemini CLI instructions
+├── profile.yaml      # Created locally by setup
+└── setup.sh          # Local onboarding
 ```
+
+## Contributing
+
+Run `npm install` once, then `npm run check` before opening a pull request.
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Requirements: Node.js 20.18 or newer, npm, Git, and a coding agent.
 
 ## Supported coding agents
 
-Persona includes auto-discovered instructions for Claude Code, Gemini CLI, Codex, Cursor, and Antigravity. Windsurf and other agents can read `.agent/persona/SKILL.md` directly.
+Persona includes auto-discovered instructions for Claude Code, Gemini CLI, Codex, Cursor, and Antigravity. Devin and other agents can read `.agent/persona/SKILL.md` directly.
 
 Persona does not install agents, edit global agent settings, or ask for access tokens. Install and sign in to your chosen agent through its official instructions.
 

--- a/materials/README.md
+++ b/materials/README.md
@@ -1,6 +1,8 @@
 # Materials Folder
 
-Drop your assets here before running the setup script. The AI will use these to build your portfolio.
+Add optional source material here. Your coding agent can use it to build a more accurate portfolio.
+
+Files stay in this repository. Review them before committing or pushing, especially if the repository is public. The local uploader accepts files up to 10 MB.
 
 ## What to Include
 
@@ -20,14 +22,14 @@ Keep filenames simple and descriptive:
 - ✅ `profile.jpg`, `ecommerce-app.png`, `resume.pdf`
 - ❌ `IMG_0234.jpg`, `Screenshot 2024-01-15 at 3.42.18 PM.png`
 
-## The AI Will
+## How your coding agent can use them
 
 1. Extract information from your resume
 2. Use your profile photo in the hero section
-3. Add project screenshots to the bento grid
+3. Add project screenshots where they fit the approved design
 4. Reference any bio or project descriptions you provide
-5. Generate missing content based on what it finds
+5. Ask about important gaps instead of inventing details
 
 ## Optional
 
-If you don't provide materials, the AI will work with just your GitHub/LinkedIn and generate everything from scratch. Materials just make it better.
+Materials are optional. Without them, your coding agent should use `profile.yaml` and ask for any important missing context.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,16 @@
 import type { NextConfig } from "next";
 
+const isGitHubPages = process.env.PERSONA_STATIC_EXPORT === "true";
+const githubPagesBasePath = process.env.GITHUB_PAGES_BASE_PATH || "";
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  ...(isGitHubPages
+    ? {
+        output: "export",
+        images: { unoptimized: true },
+        basePath: githubPagesBasePath,
+      }
+    : {}),
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,25 +8,26 @@
       "name": "persona",
       "version": "0.1.0",
       "dependencies": {
-        "@types/js-yaml": "^4.0.9",
-        "clsx": "^2.1.1",
-        "framer-motion": "^12.23.26",
-        "js-yaml": "^4.1.1",
-        "lucide-react": "^0.562.0",
-        "next": "16.1.0",
-        "pdf2json": "^3.1.4",
-        "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "js-yaml": "^5.2.1",
+        "lucide-react": "^1.25.0",
+        "next": "16.2.10",
+        "pdf2json": "^4.0.3",
+        "react": "19.2.7",
+        "react-dom": "19.2.7"
       },
       "devDependencies": {
-        "@tailwindcss/postcss": "^4",
-        "@types/node": "^20",
-        "@types/react": "^19",
-        "@types/react-dom": "^19",
-        "eslint": "^9",
-        "eslint-config-next": "16.1.0",
-        "tailwindcss": "^4",
-        "typescript": "^5"
+        "@tailwindcss/postcss": "^4.3.3",
+        "@types/node": "^22.20.1",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "eslint": "^9.39.5",
+        "eslint-config-next": "^16.2.10",
+        "tailwindcss": "^4.3.3",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.10"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -43,13 +44,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -58,9 +59,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -68,21 +69,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -99,14 +100,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -116,14 +117,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -133,9 +134,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -143,29 +144,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -175,9 +176,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -185,9 +186,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -195,9 +196,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -205,27 +206,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -235,33 +236,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -269,35 +270,35 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.7.1.tgz",
-      "integrity": "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
-      "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -305,9 +306,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -316,9 +317,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -358,15 +359,15 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -399,20 +400,20 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
-      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.2",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -422,10 +423,33 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@eslint/js": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1028,28 +1052,34 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.4.3",
-        "@emnapi/runtime": "^1.4.3",
-        "@tybys/wasm-util": "^0.10.0"
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.0.tgz",
-      "integrity": "sha512-Dd23XQeFHmhf3KBW76leYVkejHlCdB7erakC2At2apL1N08Bm+dLYNP+nNHh0tzUXfPQcNcXiQyacw0PG4Fcpw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
+      "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.1.0.tgz",
-      "integrity": "sha512-sooC/k0LCF4/jLXYHpgfzJot04lZQqsttn8XJpTguP8N3GhqXN3wSkh68no2OcZzS/qeGwKDFTqhZ8WofdXmmQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.10.tgz",
+      "integrity": "sha512-Gs8D2m21VnJeFo9qvYIIqJH94frWerWYu41BprU1pLtRVF7PCQNLiFZZ3fG+iPuj3K83Cwv/rt+msLOy8Qgu3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1057,9 +1087,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.0.tgz",
-      "integrity": "sha512-onHq8dl8KjDb8taANQdzs3XmIqQWV3fYdslkGENuvVInFQzZnuBYYOG2HGHqqtvgmEU7xWzhgndXXxnhk4Z3fQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
+      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
       "cpu": [
         "arm64"
       ],
@@ -1073,9 +1103,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.0.tgz",
-      "integrity": "sha512-Am6VJTp8KhLuAH13tPrAoVIXzuComlZlMwGr++o2KDjWiKPe3VwpxYhgV6I4gKls2EnsIMggL4y7GdXyDdJcFA==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
+      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
       "cpu": [
         "x64"
       ],
@@ -1089,11 +1119,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.0.tgz",
-      "integrity": "sha512-fVicfaJT6QfghNyg8JErZ+EMNQ812IS0lmKfbmC01LF1nFBcKfcs4Q75Yy8IqnsCqH/hZwGhqzj3IGVfWV6vpA==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
+      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1105,11 +1138,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.0.tgz",
-      "integrity": "sha512-TojQnDRoX7wJWXEEwdfuJtakMDW64Q7NrxQPviUnfYJvAx5/5wcGE+1vZzQ9F17m+SdpFeeXuOr6v3jbyusYMQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
+      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1121,11 +1157,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.0.tgz",
-      "integrity": "sha512-quhNFVySW4QwXiZkZ34SbfzNBm27vLrxZ2HwTfFFO1BBP0OY1+pI0nbyewKeq1FriqU+LZrob/cm26lwsiAi8Q==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
+      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1137,11 +1176,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.0.tgz",
-      "integrity": "sha512-6JW0z2FZUK5iOVhUIWqE4RblAhUj1EwhZ/MwteGb//SpFTOHydnhbp3868gxalwea+mbOLWO6xgxj9wA9wNvNw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
+      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1153,9 +1195,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.0.tgz",
-      "integrity": "sha512-+DK/akkAvvXn5RdYN84IOmLkSy87SCmpofJPdB8vbLmf01BzntPBSYXnMvnEEv/Vcf3HYJwt24QZ/s6sWAwOMQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
+      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
       "cpu": [
         "arm64"
       ],
@@ -1169,9 +1211,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.0.tgz",
-      "integrity": "sha512-Tr0j94MphimCCks+1rtYPzQFK+faJuhHWCegU9S9gDlgyOk8Y3kPmO64UcjyzZAlligeBtYZ/2bEyrKq0d2wqQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
+      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
       "cpu": [
         "x64"
       ],
@@ -1232,10 +1274,309 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1249,49 +1590,49 @@
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
-      "integrity": "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/remapping": "^2.3.4",
-        "enhanced-resolve": "^5.18.3",
-        "jiti": "^2.6.1",
-        "lightningcss": "1.30.2",
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.24.1",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.1.18"
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.18.tgz",
-      "integrity": "sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.1.18",
-        "@tailwindcss/oxide-darwin-arm64": "4.1.18",
-        "@tailwindcss/oxide-darwin-x64": "4.1.18",
-        "@tailwindcss/oxide-freebsd-x64": "4.1.18",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.18",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.18",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.1.18",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.1.18",
-        "@tailwindcss/oxide-linux-x64-musl": "4.1.18",
-        "@tailwindcss/oxide-wasm32-wasi": "4.1.18",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.18",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.1.18"
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.18.tgz",
-      "integrity": "sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
       "cpu": [
         "arm64"
       ],
@@ -1302,13 +1643,13 @@
         "android"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.18.tgz",
-      "integrity": "sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
       "cpu": [
         "arm64"
       ],
@@ -1319,13 +1660,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.18.tgz",
-      "integrity": "sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
       "cpu": [
         "x64"
       ],
@@ -1336,13 +1677,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.18.tgz",
-      "integrity": "sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
       "cpu": [
         "x64"
       ],
@@ -1353,13 +1694,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.18.tgz",
-      "integrity": "sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
       "cpu": [
         "arm"
       ],
@@ -1370,81 +1711,93 @@
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.18.tgz",
-      "integrity": "sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.18.tgz",
-      "integrity": "sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.18.tgz",
-      "integrity": "sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.18.tgz",
-      "integrity": "sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.18.tgz",
-      "integrity": "sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -1460,21 +1813,21 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@emnapi/wasi-threads": "^1.1.0",
-        "@napi-rs/wasm-runtime": "^1.1.0",
-        "@tybys/wasm-util": "^0.10.1",
-        "tslib": "^2.4.0"
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
-      "integrity": "sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
       "cpu": [
         "arm64"
       ],
@@ -1485,13 +1838,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.18.tgz",
-      "integrity": "sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
       "cpu": [
         "x64"
       ],
@@ -1502,27 +1855,27 @@
         "win32"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.18.tgz",
-      "integrity": "sha512-Ce0GFnzAOuPyfV5SxjXGn0CubwGcuDB0zcdaPuCSzAa/2vII24JTkH+I6jcbXLb1ctjZMZZI6OjDaLPJQL1S0g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.3.tgz",
+      "integrity": "sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.1.18",
-        "@tailwindcss/oxide": "4.1.18",
-        "postcss": "^8.4.41",
-        "tailwindcss": "4.1.18"
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "postcss": "^8.5.16",
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1530,17 +1883,29 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -1558,9 +1923,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.27.tgz",
-      "integrity": "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1568,9 +1933,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1587,101 +1952,15 @@
         "@types/react": "^19.2.0"
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.50.1.tgz",
-      "integrity": "sha512-PKhLGDq3JAg0Jk/aK890knnqduuI/Qj+udH7wCf0217IGi4gt+acgCyPVe79qoT+qKUvHMDQkwJeKW9fwl8Cyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.50.1",
-        "@typescript-eslint/type-utils": "8.50.1",
-        "@typescript-eslint/utils": "8.50.1",
-        "@typescript-eslint/visitor-keys": "8.50.1",
-        "ignore": "^7.0.0",
-        "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^8.50.1",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.50.1.tgz",
-      "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "8.50.1",
-        "@typescript-eslint/types": "8.50.1",
-        "@typescript-eslint/typescript-estree": "8.50.1",
-        "@typescript-eslint/visitor-keys": "8.50.1",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/project-service": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.50.1.tgz",
-      "integrity": "sha512-E1ur1MCVf+YiP89+o4Les/oBAVzmSbeRB0MQLfSlYtbWU17HPxZ6Bhs5iYmKZRALvEuBoXIZMOIRRc/P++Ortg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.50.1",
-        "@typescript-eslint/types": "^8.50.1",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.50.1.tgz",
-      "integrity": "sha512-mfRx06Myt3T4vuoHaKi8ZWNTPdzKPNBhiblze5N50//TSHOAQQevl/aolqA/BcqqbJ88GUnLqjjcBc8EWdBcVw==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.64.0.tgz",
+      "integrity": "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.50.1",
-        "@typescript-eslint/visitor-keys": "8.50.1"
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1689,54 +1968,12 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.50.1.tgz",
-      "integrity": "sha512-ooHmotT/lCWLXi55G4mvaUF60aJa012QzvLK0Y+Mp4WdSt17QhMhWOaBWeGTFVkb2gDgBe19Cxy1elPXylslDw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.50.1.tgz",
-      "integrity": "sha512-7J3bf022QZE42tYMO6SL+6lTPKFk/WphhRPe9Tw/el+cEwzLz1Jjz2PX3GtGQVxooLDKeMVmMt7fWpYRdG5Etg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.50.1",
-        "@typescript-eslint/typescript-estree": "8.50.1",
-        "@typescript-eslint/utils": "8.50.1",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.50.1.tgz",
-      "integrity": "sha512-v5lFIS2feTkNyMhd7AucE/9j/4V9v5iIbpVRncjk/K0sQ6Sb+Np9fgYS/63n6nwqahHQvbmujeBL7mp07Q9mlA==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
+      "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1745,108 +1982,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.50.1.tgz",
-      "integrity": "sha512-woHPdW+0gj53aM+cxchymJCrh0cyS7BTIdcDxWUNsclr9VDkOSbqC13juHzxOmQ22dDkMZEpZB+3X1WpUvzgVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/project-service": "8.50.1",
-        "@typescript-eslint/tsconfig-utils": "8.50.1",
-        "@typescript-eslint/types": "8.50.1",
-        "@typescript-eslint/visitor-keys": "8.50.1",
-        "debug": "^4.3.4",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.1.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.50.1.tgz",
-      "integrity": "sha512-lCLp8H1T9T7gPbEuJSnHwnSuO9mDf8mfK/Nion5mZmiEaQD9sWf9W4dfeFqRyqRjF06/kBuTmAqcs9sewM2NbQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.50.1",
-        "@typescript-eslint/types": "8.50.1",
-        "@typescript-eslint/typescript-estree": "8.50.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.50.1.tgz",
-      "integrity": "sha512-IrDKrw7pCRUR94zeuCSUWQ+w8JEf5ZX5jl/e6AHGSLi1/zIr0lgutfn/7JpfCey+urpgQEdrZVYzCaVVKiTwhQ==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.64.0.tgz",
+      "integrity": "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.50.1",
-        "eslint-visitor-keys": "^4.2.1"
+        "@typescript-eslint/types": "8.64.0",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1857,9 +2003,9 @@
       }
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
-      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
       "cpu": [
         "arm"
       ],
@@ -1871,9 +2017,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
-      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
       "cpu": [
         "arm64"
       ],
@@ -1885,9 +2031,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
-      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+      "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
       "cpu": [
         "arm64"
       ],
@@ -1899,9 +2045,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
-      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
       "cpu": [
         "x64"
       ],
@@ -1913,9 +2059,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
-      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
       "cpu": [
         "x64"
       ],
@@ -1927,9 +2073,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
-      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
       "cpu": [
         "arm"
       ],
@@ -1941,9 +2087,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
-      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
       "cpu": [
         "arm"
       ],
@@ -1955,13 +2101,16 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
-      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1969,13 +2118,50 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
-      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1983,13 +2169,16 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
-      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1997,13 +2186,16 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
-      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2011,13 +2203,16 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
-      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2025,13 +2220,16 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
-      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2039,13 +2237,16 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
-      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2053,23 +2254,40 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
-      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
+    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
-      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
       "cpu": [
         "wasm32"
       ],
@@ -2077,16 +2295,52 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^0.2.11"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
-      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
       "cpu": [
         "arm64"
       ],
@@ -2098,9 +2352,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
-      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
       "cpu": [
         "ia32"
       ],
@@ -2112,9 +2366,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
-      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
       "cpu": [
         "x64"
       ],
@@ -2125,10 +2379,123 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2149,9 +2516,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2357,6 +2724,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -2391,9 +2768,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.0.tgz",
-      "integrity": "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -2418,18 +2795,21 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.11",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
-      "integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2451,9 +2831,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
       "dev": true,
       "funding": [
         {
@@ -2471,11 +2851,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2485,15 +2865,15 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -2545,9 +2925,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001761",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001761.tgz",
-      "integrity": "sha512-JF9ptu1vP2coz98+5051jZ4PwQgd2ni8A+gYSN7EA7dPKIMf0pDlSUxhdmVOaV3/fYK5uWBkgSXJaRLr4+3A6g==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "funding": [
         {
           "type": "opencollective",
@@ -2563,6 +2943,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2586,15 +2976,6 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
-    },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -2813,9 +3194,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.267",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
-      "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
+      "version": "1.5.393",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
       "dev": true,
       "license": "ISC"
     },
@@ -2827,23 +3208,23 @@
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.4",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
-      "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
+      "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
-      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2930,16 +3311,16 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.2.tgz",
-      "integrity": "sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.4.0.tgz",
+      "integrity": "sha512-c/A0P0oxkACDc+cKWw8evLXK83oBKgn0qPOqCYT4x9uolpCIJAcYvJC9QYKNDRPsTeGyCrQ326jrvgZWdCdK5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.24.1",
+        "es-abstract": "^1.24.2",
         "es-errors": "^1.3.0",
         "es-set-tostringtag": "^2.1.0",
         "function-bind": "^1.1.2",
@@ -2951,11 +3332,18 @@
         "has-symbols": "^1.1.0",
         "internal-slot": "^1.1.0",
         "iterator.prototype": "^1.1.5",
-        "safe-array-concat": "^1.1.3"
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -3041,25 +3429,25 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
-      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.2",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
@@ -3078,7 +3466,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -3101,13 +3489,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.1.0.tgz",
-      "integrity": "sha512-RlPb8E2uO/Ix/w3kizxz6+6ogw99WqtNzTG0ArRZ5NEkIYcsfRb8U0j7aTG7NjRvcrsak5QtUSuxGNN2UcA58g==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.10.tgz",
+      "integrity": "sha512-HSybLOY0QKf39i4FWUqPN0xWiNDi6A6UqJmZtgDkS3zMqjXTqULvj/sueXx3cdCG0mVG+qH6k5/qdegklH1d1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.1.0",
+        "@next/eslint-plugin-next": "16.2.10",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -3127,42 +3515,7 @@
         }
       }
     },
-    "node_modules/eslint-config-next/node_modules/globals": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
-      "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
-      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.2.7",
-        "is-core-module": "^2.13.0",
-        "resolve": "^1.22.4"
-      }
-    },
-    "node_modules/eslint-import-resolver-node/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-import-resolver-typescript": {
+    "node_modules/eslint-config-next/node_modules/eslint-import-resolver-typescript": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
       "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
@@ -3197,35 +3550,7 @@
         }
       }
     },
-    "node_modules/eslint-module-utils": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
-      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.2.7"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-plugin-import": {
+    "node_modules/eslint-config-next/node_modules/eslint-plugin-import": {
       "version": "2.32.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
@@ -3259,7 +3584,7 @@
         "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
       }
     },
-    "node_modules/eslint-plugin-import/node_modules/debug": {
+    "node_modules/eslint-config-next/node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
@@ -3269,7 +3594,7 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/eslint-plugin-jsx-a11y": {
+    "node_modules/eslint-config-next/node_modules/eslint-plugin-jsx-a11y": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
       "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
@@ -3299,7 +3624,7 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
       }
     },
-    "node_modules/eslint-plugin-react": {
+    "node_modules/eslint-config-next/node_modules/eslint-plugin-react": {
       "version": "7.37.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
@@ -3332,10 +3657,353 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
       }
     },
+    "node_modules/eslint-config-next/node_modules/globals": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
+      "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/resolve": {
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.2",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.64.0.tgz",
+      "integrity": "sha512-0qg+pDNMnqYzqH9AnNK+39tejHvsShUOUUoRUgtnTGE7QuMZhiFDnozq8nHJVq+Wae6NMLKNWLg5WmkcC/ndyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.64.0",
+        "@typescript-eslint/parser": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0",
+        "@typescript-eslint/utils": "8.64.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
+      "integrity": "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/type-utils": "8.64.0",
+        "@typescript-eslint/utils": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.64.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.64.0.tgz",
+      "integrity": "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0",
+        "@typescript-eslint/utils": "8.64.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.64.0.tgz",
+      "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.64.0.tgz",
+      "integrity": "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.64.0",
+        "@typescript-eslint/tsconfig-utils": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/project-service": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.64.0.tgz",
+      "integrity": "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.64.0",
+        "@typescript-eslint/types": "^8.64.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.64.0.tgz",
+      "integrity": "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.64.0.tgz",
+      "integrity": "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
+      "integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3349,25 +4017,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/resolve": {
-      "version": "2.0.0-next.5",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
-      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -3388,6 +4038,19 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
@@ -3418,10 +4081,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3454,6 +4130,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3462,6 +4148,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3583,9 +4279,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3605,31 +4301,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/framer-motion": {
-      "version": "12.23.26",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.26.tgz",
-      "integrity": "sha512-cPcIhgR42xBn1Uj+PzOyheMtZ73H927+uWPDVhUMqxy8UHt6Okavb6xIz9J/phFUHUj0OncR6UvMfJTXoc/LKA==",
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
       "license": "MIT",
-      "dependencies": {
-        "motion-dom": "^12.23.23",
-        "motion-utils": "^12.23.6",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -3751,9 +4435,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
-      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3908,9 +4592,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4071,9 +4755,9 @@
       }
     },
     "node_modules/is-bun-module/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4097,13 +4781,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4437,9 +5121,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4454,15 +5138,25 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/jsesc": {
@@ -4573,9 +5267,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
-      "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -4589,23 +5283,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.30.2",
-        "lightningcss-darwin-arm64": "1.30.2",
-        "lightningcss-darwin-x64": "1.30.2",
-        "lightningcss-freebsd-x64": "1.30.2",
-        "lightningcss-linux-arm-gnueabihf": "1.30.2",
-        "lightningcss-linux-arm64-gnu": "1.30.2",
-        "lightningcss-linux-arm64-musl": "1.30.2",
-        "lightningcss-linux-x64-gnu": "1.30.2",
-        "lightningcss-linux-x64-musl": "1.30.2",
-        "lightningcss-win32-arm64-msvc": "1.30.2",
-        "lightningcss-win32-x64-msvc": "1.30.2"
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
-      "integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
       ],
@@ -4624,9 +5318,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz",
-      "integrity": "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
       ],
@@ -4645,9 +5339,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
-      "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
       ],
@@ -4666,9 +5360,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
-      "integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
       ],
@@ -4687,9 +5381,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
-      "integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
       ],
@@ -4708,13 +5402,16 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
-      "integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4729,13 +5426,16 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
-      "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4750,13 +5450,16 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
-      "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4771,13 +5474,16 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
-      "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4792,9 +5498,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
-      "integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
       ],
@@ -4813,9 +5519,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
-      "integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
       ],
@@ -4880,9 +5586,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.562.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.562.0.tgz",
-      "integrity": "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.25.0.tgz",
+      "integrity": "sha512-/mdJTRbiwcLOQ1NZZK1amZF9rIZyvO18D6r9TngE6TG1NmqHgFuT4eE7Xrkm9UsXMbBJD1NlfwHVltCDWHrOTw==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -4933,9 +5639,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4955,21 +5661,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/motion-dom": {
-      "version": "12.23.23",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.23.tgz",
-      "integrity": "sha512-n5yolOs0TQQBRUFImrRfs/+6X4p3Q4n1dUEqt/H58Vx7OW6RF+foWEgmTVDhIWJIMXOuNNL0apKH2S16en9eiA==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-utils": "^12.23.6"
-      }
-    },
-    "node_modules/motion-utils": {
-      "version": "12.23.6",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
-      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
-      "license": "MIT"
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4978,9 +5669,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -5019,14 +5710,14 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.0.tgz",
-      "integrity": "sha512-Y+KbmDbefYtHDDQKLNrmzE/YYzG2msqo2VXhzh5yrJ54tx/6TmGdkR5+kP9ma7i7LwZpZMfoY3m/AoPPPKxtVw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
+      "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.1.0",
+        "@next/env": "16.2.10",
         "@swc/helpers": "0.5.15",
-        "baseline-browser-mapping": "^2.8.3",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -5038,15 +5729,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.0",
-        "@next/swc-darwin-x64": "16.1.0",
-        "@next/swc-linux-arm64-gnu": "16.1.0",
-        "@next/swc-linux-arm64-musl": "16.1.0",
-        "@next/swc-linux-x64-gnu": "16.1.0",
-        "@next/swc-linux-x64-musl": "16.1.0",
-        "@next/swc-win32-arm64-msvc": "16.1.0",
-        "@next/swc-win32-x64-msvc": "16.1.0",
-        "sharp": "^0.34.4"
+        "@next/swc-darwin-arm64": "16.2.10",
+        "@next/swc-darwin-x64": "16.2.10",
+        "@next/swc-linux-arm64-gnu": "16.2.10",
+        "@next/swc-linux-arm64-musl": "16.2.10",
+        "@next/swc-linux-x64-gnu": "16.2.10",
+        "@next/swc-linux-x64-musl": "16.2.10",
+        "@next/swc-win32-arm64-msvc": "16.2.10",
+        "@next/swc-win32-x64-msvc": "16.2.10",
+        "sharp": "^0.34.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -5071,40 +5762,34 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
+    "node_modules/node-exports-info": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.2.tgz",
+      "integrity": "sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -5229,6 +5914,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5337,31 +6036,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pdf2json": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/pdf2json/-/pdf2json-3.1.4.tgz",
-      "integrity": "sha512-rS+VapXpXZr+5lUpHmRh3ugXdFXp24p1RyG24yP1DMpqP4t0mrYNGpLtpSbWD42PnQ59GIXofxF+yWb7M+3THg==",
-      "bundleDependencies": [
-        "@xmldom/xmldom"
-      ],
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/pdf2json/-/pdf2json-4.0.3.tgz",
+      "integrity": "sha512-QErPemxRHDI2RUli3+9/mv4V6Ib9VWI+UoP2S82yXEQtoXzWvu9NSjjo3vyiUiVJv+CJFuzNiKUI+UFFUdv8Lg==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.8.10"
-      },
       "bin": {
         "pdf2json": "bin/pdf2json.js"
       },
       "engines": {
-        "node": ">=18.12.1",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/pdf2json/node_modules/@xmldom/xmldom": {
-      "version": "0.8.10",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
+        "node": ">=20.18.0"
       }
     },
     "node_modules/picocolors": {
@@ -5371,9 +6062,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5394,10 +6085,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -5414,7 +6104,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5476,24 +6166,24 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
-      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.3"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-is": {
@@ -5597,6 +6287,40 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/run-parallel": {
@@ -5900,6 +6624,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5913,6 +6644,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
     },
@@ -6116,16 +6861,16 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
-      "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6136,15 +6881,32 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -6172,9 +6934,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6182,6 +6944,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -6198,9 +6970,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6334,9 +7106,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6345,30 +7117,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/typescript-eslint": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.50.1.tgz",
-      "integrity": "sha512-ytTHO+SoYSbhAH9CrYnMhiLx8To6PSSvqnvXyPUgPETCvB6eBKmTI9w6XMPS3HsBRGkwTVBX+urA8dYQx6bHfQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.50.1",
-        "@typescript-eslint/parser": "8.50.1",
-        "@typescript-eslint/typescript-estree": "8.50.1",
-        "@typescript-eslint/utils": "8.50.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -6398,38 +7146,41 @@
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
-      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+      "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "napi-postinstall": "^0.3.0"
+        "napi-postinstall": "^0.3.4"
       },
       "funding": {
         "url": "https://opencollective.com/unrs-resolver"
       },
       "optionalDependencies": {
-        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
-        "@unrs/resolver-binding-android-arm64": "1.11.1",
-        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
-        "@unrs/resolver-binding-darwin-x64": "1.11.1",
-        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
-        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
-        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
-        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
-        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
-        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
-        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
-        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
-        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
-        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+        "@unrs/resolver-binding-android-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-x64": "1.12.2",
+        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -6471,6 +7222,200 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/which": {
@@ -6578,6 +7523,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -6609,9 +7571,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
-      "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -2,34 +2,43 @@
   "name": "persona",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=20.18.0"
+  },
   "scripts": {
-    "dev": "next dev",
-    "dev:clean": "rm -rf .next && next dev",
+    "dev": "next dev --hostname 127.0.0.1",
+    "dev:clean": "rm -rf .next && next dev --hostname 127.0.0.1",
     "build": "rm -rf .next && next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "setup:check": "bash ./setup.sh --check",
+    "check": "npm run lint && npm run typecheck && npm run test && npm run setup:check && npm run build",
+    "audit": "npm audit --audit-level=high",
     "clean": "rm -rf .next"
   },
   "dependencies": {
-    "@types/js-yaml": "^4.0.9",
-    "clsx": "^2.1.1",
-    "framer-motion": "^12.23.26",
-    "js-yaml": "^4.1.1",
-    "lucide-react": "^0.562.0",
-    "next": "16.1.0",
-    "pdf2json": "^3.1.4",
-    "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "js-yaml": "^5.2.1",
+    "lucide-react": "^1.25.0",
+    "next": "16.2.10",
+    "pdf2json": "^4.0.3",
+    "react": "19.2.7",
+    "react-dom": "19.2.7"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
-    "eslint": "^9",
-    "eslint-config-next": "16.1.0",
-    "lightningcss": "^1.24.1",
-    "tailwindcss": "^4",
-    "typescript": "^5"
+    "@tailwindcss/postcss": "^4.3.3",
+    "@types/node": "^22.20.1",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "eslint": "^9.39.5",
+    "eslint-config-next": "^16.2.10",
+    "tailwindcss": "^4.3.3",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
+  },
+  "overrides": {
+    "flatted": "3.4.2",
+    "postcss": "8.5.19"
   }
 }

--- a/profile.example.yaml
+++ b/profile.example.yaml
@@ -1,5 +1,5 @@
 # Persona: Profile Configuration
-# Most fields are OPTIONAL - the AI will research and fill in what's missing
+# Most fields are OPTIONAL - your coding agent can ask before researching gaps
 # Only provide what you want to control directly
 
 # ========================================
@@ -11,13 +11,23 @@ cli: "claude-code"  # REQUIRED - AI CLI tool (claude-code, codex, gemini, aider,
 # ========================================
 # OPTIONAL: Contact & Social Links
 # ========================================
-# The AI will try to find these via web search if not provided
+# Your coding agent may offer to find these via web search if not provided
 # Only include what you want publicly listed on your portfolio
 email: ""          # Optional - leave blank to exclude
 github: ""         # Optional - AI will search for it if blank
 linkedin: ""       # Optional - AI will search (but may be blocked)
 twitter: ""        # Optional
 website: ""        # Optional - your existing portfolio/blog
+
+# ========================================
+# OPTIONAL: Portfolio Sections
+# ========================================
+sections:
+  - hero
+  - about
+  - experience
+  - projects
+  - contact
 
 # ========================================
 # OPTIONAL: Design Preferences (defaults shown)

--- a/profile.example.yaml
+++ b/profile.example.yaml
@@ -6,7 +6,7 @@
 # REQUIRED: Basic Info
 # ========================================
 name: "Your Name"  # REQUIRED - your full name
-cli: "claude-code"  # REQUIRED - AI CLI tool (claude-code, codex, gemini, aider, cursor, other)
+cli: "claude-code"  # REQUIRED - AI CLI tool (claude-code, codex, gemini, aider, cursor, devin, antigravity, other)
 
 # ========================================
 # OPTIONAL: Contact & Social Links

--- a/setup.sh
+++ b/setup.sh
@@ -173,7 +173,7 @@ printf '%s\n' '  1) Claude Code'
 printf '%s\n' '  2) Gemini CLI'
 printf '%s\n' '  3) Codex'
 printf '%s\n' '  4) Cursor'
-printf '%s\n' '  5) Windsurf'
+printf '%s\n' '  5) Devin CLI'
 printf '%s\n' '  6) Antigravity'
 printf '%s\n' '  7) Other'
 read -r -p '  Select: ' cli_choice
@@ -183,7 +183,7 @@ case "$cli_choice" in
   2) cli_name='Gemini CLI'; cli_command='gemini'; instruction_file='GEMINI.md' ;;
   3) cli_name='Codex'; cli_command='codex'; instruction_file='AGENTS.md' ;;
   4) cli_name='Cursor'; cli_command='cursor'; instruction_file='.cursorrules' ;;
-  5) cli_name='Windsurf'; cli_command='windsurf'; instruction_file='.agent/persona/SKILL.md' ;;
+  5) cli_name='Devin CLI'; cli_command='devin'; instruction_file='.agent/persona/SKILL.md' ;;
   6) cli_name='Antigravity'; cli_command='antigravity'; instruction_file='.antigravity/rules.md' ;;
   7) cli_name='your coding agent'; cli_command=''; instruction_file='.agent/persona/SKILL.md' ;;
   *) printf "  %b Choose a number from 1 to 7.\n" "$CROSS"; exit 1 ;;
@@ -204,7 +204,7 @@ if ! command -v "$cli_command" >/dev/null 2>&1; then
 fi
 
 read -r -p "  Press Enter to open $cli_name..."
-if [ "$cli_command" = 'cursor' ] || [ "$cli_command" = 'windsurf' ] || [ "$cli_command" = 'antigravity' ]; then
+if [ "$cli_command" = 'cursor' ] || [ "$cli_command" = 'antigravity' ]; then
   "$cli_command" "$PROJECT_DIR"
 else
   exec "$cli_command"

--- a/setup.sh
+++ b/setup.sh
@@ -1,11 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Persona: Setup Script
-# Streamlined onboarding for AI-powered portfolio generation
+set -uo pipefail
 
 PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIN_NODE_MAJOR=20
+MIN_NODE_MINOR=18
 
-# Colors
 CYAN='\033[0;36m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -13,725 +13,199 @@ RED='\033[0;31m'
 DIM='\033[2m'
 NC='\033[0m'
 BOLD='\033[1m'
-
-# Symbols
 CHECK="${GREEN}✓${NC}"
 CROSS="${RED}✗${NC}"
-ARROW="${CYAN}→${NC}"
-
-clear
-
-echo -e "${CYAN}"
-cat << "EOF"
-    ____
-   / __ \___  ______________  ____  ____ _
-  / /_/ / _ \/ ___/ ___/ __ \/ __ \/ __ `/
- / ____/  __/ /  (__  ) /_/ / / / / /_/ /
-/_/    \___/_/  /____/\____/_/ /_/\__,_/
-
-EOF
-echo -e "${NC}"
-
-echo -e "${BOLD}Drop-in portfolio kit for AI coding agents${NC}"
-echo -e "${DIM}Works with Claude Code, Gemini CLI, Codex, Cursor, Antigravity & more${NC}"
-echo ""
 
 cd "$PROJECT_DIR"
 
-# ============================================
-# Pre-flight checks
-# ============================================
-
-echo -e "${BOLD}Checking requirements...${NC}"
-echo ""
-
-# Check Node.js
-if command -v node &> /dev/null; then
-    NODE_VERSION=$(node -v | sed 's/v//')
-    NODE_MAJOR=$(echo "$NODE_VERSION" | cut -d. -f1)
-    if [ "$NODE_MAJOR" -ge 18 ]; then
-        echo -e "  $CHECK Node.js v$NODE_VERSION"
-    else
-        echo -e "  ${YELLOW}⚠${NC} Node.js v$NODE_VERSION ${DIM}(v18+ recommended)${NC}"
-    fi
-else
-    echo -e "  $CROSS Node.js not found"
-    echo ""
-    echo -e "  ${YELLOW}Install Node.js first:${NC}"
-    echo -e "    https://nodejs.org/"
-    exit 1
-fi
-
-# Check npm
-if command -v npm &> /dev/null; then
-    NPM_VERSION=$(npm -v 2>/dev/null)
-    echo -e "  $CHECK npm v$NPM_VERSION"
-else
-    echo -e "  $CROSS npm not found"
-    exit 1
-fi
-
-# Check for AI CLI
-CLI_FOUND=""
-for cli in claude gemini codex; do
-    if command -v $cli &> /dev/null; then
-        CLI_FOUND="$cli"
-        break
-    fi
-done
-
-if [ -n "$CLI_FOUND" ]; then
-    echo -e "  $CHECK AI CLI: $CLI_FOUND"
-else
-    echo -e "  ${YELLOW}○${NC} No AI CLI detected ${DIM}(will install or configure later)${NC}"
-fi
-
-echo ""
-
-# ============================================
-# Step 1: Git Setup (ensure user owns the repo)
-# ============================================
-
-echo -e "${BOLD}Step 1: Repository Setup${NC}"
-echo ""
-
-# Check if git remote points to template repo
-REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
-if echo "$REMOTE_URL" | grep -qi "JacbK/persona\|jacobkieser/persona"; then
-    echo -e "  ${YELLOW}⚠ Git remote points to the template repo${NC}"
-    echo -e "  ${DIM}You need your own repository to deploy${NC}"
-    echo ""
-    echo -e "  ${BOLD}Options:${NC}"
-    echo -e "    1) Create a new GitHub repo for me ${DIM}(requires gh CLI)${NC}"
-    echo -e "    2) I'll set up my own repo later"
-    echo ""
-    read -p "  Select [2]: " repo_choice
-    repo_choice=${repo_choice:-2}
-
-    if [ "$repo_choice" = "1" ]; then
-        if command -v gh &> /dev/null; then
-            echo ""
-            read -p "  Repository name [my-portfolio]: " repo_name
-            repo_name=${repo_name:-my-portfolio}
-
-            echo -e "  Creating repository..."
-            if gh repo create "$repo_name" --public --source=. --remote=origin 2>/dev/null; then
-                echo -e "  $CHECK Created github.com/$(gh api user -q .login)/$repo_name"
-            else
-                # If repo exists or creation failed, try to set remote
-                echo -e "  ${YELLOW}Creating repo failed. You may need to create it manually.${NC}"
-            fi
-        else
-            echo -e "  ${YELLOW}GitHub CLI not installed. Install with: brew install gh${NC}"
-            echo -e "  ${DIM}You can set up your repo later before deploying${NC}"
-        fi
-    else
-        echo -e "  ${DIM}Remember to create your own repo before deploying${NC}"
-        echo -e "  ${DIM}Run: gh repo create my-portfolio --public --source=. --push${NC}"
-    fi
-    echo ""
-else
-    echo -e "  $CHECK Git repository configured"
-fi
-
-# Auto-delete template README if it exists and still has Persona content
-if [ -f "README.md" ] && grep -q "Persona" README.md 2>/dev/null; then
-    rm README.md
-    echo -e "  $CHECK Deleted template README"
-fi
-
-echo ""
-
-# ============================================
-# Step 2: Dependencies
-# ============================================
-
-echo -e "${BOLD}Step 2: Dependencies${NC}"
-echo ""
-
-if [ ! -d "node_modules" ]; then
-    echo -e "  Installing packages..."
-    if npm install --silent 2>/dev/null; then
-        echo -e "  $CHECK Dependencies installed"
-    else
-        echo -e "  ${YELLOW}Installing with verbose output...${NC}"
-        npm install
-    fi
-
-    # Fix for Tailwind 4 / lightningcss on macOS ARM64
-    if [[ "$OSTYPE" == "darwin"* ]] && [[ "$(uname -m)" == "arm64" ]]; then
-        echo -e "  ${DIM}Verifying binaries for Apple Silicon...${NC}"
-        npm rebuild lightningcss --silent >/dev/null 2>&1 || true
-    fi
-else
-    echo -e "  $CHECK Dependencies already installed"
-fi
-
-echo ""
-
-# ============================================
-# Step 3: Configuration
-# ============================================
-
-echo -e "${BOLD}Step 3: Configuration${NC}"
-echo ""
-
-if [ -f "profile.yaml" ]; then
-    # Profile exists - offer to reconfigure or continue
-    echo -e "  $CHECK Found existing profile.yaml"
-    echo ""
-    echo -e "  ${BOLD}What would you like to do?${NC}"
-    echo -e "    1) Continue with existing config → Build portfolio"
-    echo -e "    2) Edit config → Open config UI to make changes"
-    echo ""
-    read -p "  Select [1]: " config_choice
-    config_choice=${config_choice:-1}
-
-    if [ "$config_choice" = "2" ]; then
-        NEED_CONFIG=true
-    else
-        NEED_CONFIG=false
-        echo ""
-        echo -e "  ${DIM}Tip: Run ./setup.sh again anytime to edit your config${NC}"
-    fi
-else
-    # No profile.yaml in project directory - need to configure
-    NEED_CONFIG=true
-fi
-
-if [ "$NEED_CONFIG" = true ]; then
-    echo ""
-    echo -e "  Opening configuration UI..."
-    echo ""
-    echo -e "  ${CYAN}┌───────────────────────────────────────────────┐${NC}"
-    echo -e "  ${CYAN}│${NC}  Your browser will open automatically         ${CYAN}│${NC}"
-    echo -e "  ${CYAN}│${NC}  ${DIM}Or visit:${NC} ${BOLD}http://localhost:3000/config${NC}     ${CYAN}│${NC}"
-    echo -e "  ${CYAN}│${NC}                                               ${CYAN}│${NC}"
-    echo -e "  ${CYAN}│${NC}  1. Fill in your name ${DIM}(required)${NC}            ${CYAN}│${NC}"
-    echo -e "  ${CYAN}│${NC}  2. Pick design inspirations ${DIM}(optional)${NC}     ${CYAN}│${NC}"
-    echo -e "  ${CYAN}│${NC}  3. Click ${GREEN}Save to Project${NC}                  ${CYAN}│${NC}"
-    echo -e "  ${CYAN}│${NC}                                               ${CYAN}│${NC}"
-    echo -e "  ${CYAN}│${NC}  ${DIM}The script will continue automatically${NC}     ${CYAN}│${NC}"
-    echo -e "  ${CYAN}└───────────────────────────────────────────────┘${NC}"
-    echo ""
-
-    # Clear .next cache before starting (prevents Turbopack/lightningcss corruption)
-    rm -rf .next
-
-    # Start dev server in background
-    npm run dev &>/dev/null &
-    DEV_PID=$!
-
-    # Give server time to start
-    sleep 2
-
-    # Open browser
-    if command -v open &> /dev/null; then
-        open "http://localhost:3000/config"
-    elif command -v xdg-open &> /dev/null; then
-        xdg-open "http://localhost:3000/config"
-    else
-        echo -e "  ${ARROW} Open in browser: ${CYAN}http://localhost:3000/config${NC}"
-    fi
-
-    # Wait for config save (using sentinel file for reliable detection)
-    echo -e "  Waiting for you to save your config..."
-    echo -e "  ${DIM}(Press Ctrl+C to cancel)${NC}"
-    echo ""
-
-    # Remove any stale sentinel file
-    rm -f .config-saved
-
-    WAIT_COUNT=0
-    while true; do
-        # Check for sentinel file written by save-config API
-        if [ -f ".config-saved" ]; then
-            rm -f .config-saved  # Clean up sentinel
-            echo -e "  $CHECK Config saved!"
-            break
-        fi
-
-        sleep 1
-        WAIT_COUNT=$((WAIT_COUNT + 1))
-
-        # Show periodic reminder
-        if [ $((WAIT_COUNT % 30)) -eq 0 ]; then
-            echo -e "  ${DIM}Still waiting... Click 'Save to Project' when ready${NC}"
-        fi
-    done
-
-    # Kill the dev server
-    kill $DEV_PID 2>/dev/null
-    wait $DEV_PID 2>/dev/null
-
-    echo ""
-fi
-
-# Verify profile exists
-if [ ! -f "profile.yaml" ]; then
-    echo -e "  $CROSS No profile.yaml found"
-    echo -e "  Run ${CYAN}./setup.sh${NC} again to configure"
-    exit 1
-fi
-
-echo ""
-
-# ============================================
-# Step 4: AI Tool Setup
-# ============================================
-
-echo -e "${BOLD}Step 4: AI Assistant${NC}"
-echo ""
-
-# Always prompt user to select their AI coding assistant
-echo -e "  ${BOLD}Which AI coding assistant will you use?${NC}"
-echo ""
-echo -e "    1) Claude Code ${DIM}(Anthropic)${NC}"
-echo -e "    2) Gemini CLI ${DIM}(Google)${NC}"
-echo -e "    3) Codex ${DIM}(OpenAI)${NC}"
-echo -e "    4) Cursor"
-echo -e "    5) Windsurf ${DIM}(Codeium)${NC}"
-echo -e "    6) Antigravity ${DIM}(Google)${NC}"
-echo -e "    7) Other ${DIM}(Aider, etc.)${NC}"
-echo ""
-
-# Detect installed CLIs to show which are available
-DETECTED_CLIS=""
-if command -v claude &> /dev/null; then
-    DETECTED_CLIS="${DETECTED_CLIS}claude-code "
-fi
-if command -v gemini &> /dev/null; then
-    DETECTED_CLIS="${DETECTED_CLIS}gemini "
-fi
-if command -v codex &> /dev/null; then
-    DETECTED_CLIS="${DETECTED_CLIS}codex "
-fi
-if [ -n "$DETECTED_CLIS" ]; then
-    echo -e "  ${DIM}Detected:${NC} ${DETECTED_CLIS}"
-fi
-
-read -p "  Select: " cli_choice
-
-case "$cli_choice" in
-    1) CLI_TOOL="claude-code" ;;
-    2) CLI_TOOL="gemini" ;;
-    3) CLI_TOOL="codex" ;;
-    4) CLI_TOOL="cursor" ;;
-    5) CLI_TOOL="windsurf" ;;
-    6) CLI_TOOL="antigravity" ;;
-    7) CLI_TOOL="other" ;;
-    *)
-        echo -e "  ${YELLOW}Invalid selection, please choose 1-7${NC}"
-        exit 1
-        ;;
-esac
-
-echo ""
-
-echo -e "  Selected: ${CYAN}$CLI_TOOL${NC}"
-echo ""
-
-# Check if CLI is installed
-CLI_INSTALLED=false
-case "$CLI_TOOL" in
-    "claude-code")
-        if command -v claude &> /dev/null; then
-            CLI_INSTALLED=true
-        fi
-        ;;
-    "codex")
-        if command -v codex &> /dev/null; then
-            CLI_INSTALLED=true
-        fi
-        ;;
-    "gemini")
-        if command -v gemini &> /dev/null; then
-            CLI_INSTALLED=true
-        fi
-        ;;
-    "cursor"|"windsurf"|"antigravity")
-        CLI_INSTALLED=true  # IDE - opens manually
-        ;;
-    *)
-        CLI_INSTALLED=true  # Custom - user handles it
-        ;;
-esac
-
-if [ "$CLI_INSTALLED" = false ]; then
-    echo -e "  ${YELLOW}⚠ $CLI_TOOL is not installed${NC}"
-    echo ""
-    case "$CLI_TOOL" in
-        "claude-code")
-            echo -e "  Install with: ${CYAN}npm install -g @anthropic-ai/claude-code${NC}"
-            ;;
-        "codex")
-            echo -e "  Install with: ${CYAN}npm install -g @openai/codex${NC}"
-            ;;
-        "gemini")
-            echo -e "  Install with: ${CYAN}npm install -g @google/gemini-cli${NC}"
-            ;;
-    esac
-    echo ""
-    read -p "  Press Enter after installing, or Ctrl+C to exit..."
-    echo ""
-fi
-
-# MCP setup for supported CLIs (Claude Code, Codex, Gemini CLI)
-setup_mcp() {
-    local cli="$1"
-
-    echo ""
-    echo -e "  ${DIM}Optional: Enable AI-driven deployment${NC}"
-    echo -e "  ${DIM}This lets your AI assistant deploy directly to hosting platforms${NC}"
-    echo ""
-    echo -e "  ${BOLD}Which deployment integrations do you want?${NC}"
-    echo -e "    1) GitHub only"
-    echo -e "    2) Vercel only"
-    echo -e "    3) Both GitHub and Vercel"
-    echo -e "    4) Skip (set up later)"
-    echo ""
-    read -p "  Select [4]: " deploy_choice
-    deploy_choice=${deploy_choice:-4}
-
-    WANT_GITHUB=false
-    WANT_VERCEL=false
-
-    case "$deploy_choice" in
-        1) WANT_GITHUB=true ;;
-        2) WANT_VERCEL=true ;;
-        3) WANT_GITHUB=true; WANT_VERCEL=true ;;
-        4)
-            echo -e "  ${DIM}Skipping deployment integration${NC}"
-            return
-            ;;
-        *)
-            echo -e "  ${DIM}Skipping deployment integration${NC}"
-            return
-            ;;
-    esac
-
-    echo ""
-
-    # Get GitHub token if requested
-    GITHUB_TOKEN=""
-    if [ "$WANT_GITHUB" = true ]; then
-        if command -v gh &> /dev/null; then
-            GITHUB_TOKEN=$(gh auth token 2>/dev/null || echo "")
-            if [ -n "$GITHUB_TOKEN" ]; then
-                echo -e "  $CHECK Found GitHub token from gh CLI"
-            else
-                echo -e "  ${DIM}GitHub CLI found but not authenticated${NC}"
-                echo -e "  ${CYAN}Get a token at:${NC} https://github.com/settings/tokens/new"
-                echo -e "  ${DIM}Required scopes: repo, read:user${NC}"
-                echo ""
-                read -p "  GitHub token: " GITHUB_TOKEN
-            fi
-        else
-            echo -e "  ${YELLOW}○${NC} GitHub CLI (gh) not installed"
-            echo ""
-            echo -e "  ${DIM}The gh CLI makes GitHub integration easier.${NC}"
-            echo -e "  ${DIM}Options:${NC}"
-            echo -e "    1) Install gh CLI ${DIM}(recommended)${NC}"
-            echo -e "    2) Enter a personal access token manually"
-            echo -e "    3) Skip GitHub integration"
-            echo ""
-            read -p "  Select [1]: " gh_choice
-            gh_choice=${gh_choice:-1}
-
-            case "$gh_choice" in
-                1)
-                    echo ""
-                    echo -e "  Installing GitHub CLI..."
-                    if [[ "$OSTYPE" == "darwin"* ]]; then
-                        if command -v brew &> /dev/null; then
-                            brew install gh && echo -e "  $CHECK GitHub CLI installed"
-                        else
-                            echo -e "  ${YELLOW}Homebrew not found. Install gh manually:${NC}"
-                            echo -e "    https://cli.github.com/manual/installation"
-                        fi
-                    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-                        if command -v apt-get &> /dev/null; then
-                            sudo apt-get update && sudo apt-get install -y gh && echo -e "  $CHECK GitHub CLI installed"
-                        elif command -v dnf &> /dev/null; then
-                            sudo dnf install -y gh && echo -e "  $CHECK GitHub CLI installed"
-                        else
-                            echo -e "  ${YELLOW}Install gh manually:${NC} https://cli.github.com/manual/installation"
-                        fi
-                    else
-                        echo -e "  ${YELLOW}Install gh manually:${NC} https://cli.github.com/manual/installation"
-                    fi
-
-                    # If gh was installed, authenticate
-                    if command -v gh &> /dev/null; then
-                        echo ""
-                        echo -e "  ${CYAN}Authenticating with GitHub...${NC}"
-                        gh auth login
-                        GITHUB_TOKEN=$(gh auth token 2>/dev/null || echo "")
-                        if [ -n "$GITHUB_TOKEN" ]; then
-                            echo -e "  $CHECK GitHub authenticated"
-                        fi
-                    fi
-                    ;;
-                2)
-                    echo ""
-                    echo -e "  ${CYAN}Get a token at:${NC} https://github.com/settings/tokens/new"
-                    echo -e "  ${DIM}Required scopes: repo, read:user${NC}"
-                    echo ""
-                    read -p "  GitHub token: " GITHUB_TOKEN
-                    ;;
-                3)
-                    echo -e "  ${DIM}Skipping GitHub integration${NC}"
-                    ;;
-            esac
-        fi
-    fi
-
-    # Get Vercel token if requested
-    VERCEL_TOKEN=""
-    if [ "$WANT_VERCEL" = true ]; then
-        echo ""
-
-        # Check if Vercel CLI is installed
-        if command -v vercel &> /dev/null; then
-            echo -e "  $CHECK Vercel CLI installed"
-        else
-            echo -e "  ${YELLOW}○${NC} Vercel CLI not installed"
-            echo ""
-            echo -e "  ${DIM}The Vercel CLI is optional but useful for manual deploys.${NC}"
-            echo -e "  ${DIM}Options:${NC}"
-            echo -e "    1) Install Vercel CLI"
-            echo -e "    2) Continue without CLI ${DIM}(AI can still deploy via API)${NC}"
-            echo ""
-            read -p "  Select [2]: " vercel_cli_choice
-            vercel_cli_choice=${vercel_cli_choice:-2}
-
-            if [ "$vercel_cli_choice" = "1" ]; then
-                echo ""
-                echo -e "  Installing Vercel CLI..."
-                if npm install -g vercel 2>/dev/null; then
-                    echo -e "  $CHECK Vercel CLI installed"
-                else
-                    echo -e "  ${YELLOW}Failed to install. Try: npm install -g vercel${NC}"
-                fi
-            fi
-        fi
-
-        echo ""
-        echo -e "  ${CYAN}Get a Vercel token at:${NC} https://vercel.com/account/tokens"
-        echo ""
-        read -p "  Vercel token: " VERCEL_TOKEN
-    fi
-
-    # Configure based on CLI
-    case "$cli" in
-        "claude-code")
-            if [ -n "$GITHUB_TOKEN" ]; then
-                if claude mcp add github -e GITHUB_PERSONAL_ACCESS_TOKEN="$GITHUB_TOKEN" -- npx -y @modelcontextprotocol/server-github 2>/dev/null; then
-                    echo -e "  $CHECK GitHub MCP configured"
-                fi
-            fi
-            if [ -n "$VERCEL_TOKEN" ]; then
-                if claude mcp add vercel -e VERCEL_API_TOKEN="$VERCEL_TOKEN" -- npx -y vercel-mcp-server 2>/dev/null; then
-                    echo -e "  $CHECK Vercel MCP configured"
-                fi
-            fi
-            ;;
-        "codex")
-            if [ -n "$GITHUB_TOKEN" ]; then
-                if codex mcp add github -- npx -y @modelcontextprotocol/server-github 2>/dev/null; then
-                    # Set env var in config
-                    echo -e "  $CHECK GitHub MCP configured"
-                    echo -e "  ${DIM}Note: Set GITHUB_PERSONAL_ACCESS_TOKEN in your shell${NC}"
-                fi
-            fi
-            if [ -n "$VERCEL_TOKEN" ]; then
-                if codex mcp add vercel -- npx -y vercel-mcp-server 2>/dev/null; then
-                    echo -e "  $CHECK Vercel MCP configured"
-                    echo -e "  ${DIM}Note: Set VERCEL_API_TOKEN in your shell${NC}"
-                fi
-            fi
-            ;;
-        "gemini")
-            # Gemini uses ~/.gemini/settings.json
-            GEMINI_SETTINGS="$HOME/.gemini/settings.json"
-            mkdir -p "$HOME/.gemini"
-
-            # Build MCP config
-            MCP_CONFIG="{\"mcpServers\":{"
-            SERVERS=""
-
-            if [ -n "$GITHUB_TOKEN" ]; then
-                SERVERS="\"github\":{\"command\":\"npx\",\"args\":[\"-y\",\"@modelcontextprotocol/server-github\"],\"env\":{\"GITHUB_PERSONAL_ACCESS_TOKEN\":\"$GITHUB_TOKEN\"}}"
-            fi
-
-            if [ -n "$VERCEL_TOKEN" ]; then
-                if [ -n "$SERVERS" ]; then
-                    SERVERS="$SERVERS,"
-                fi
-                SERVERS="$SERVERS\"vercel\":{\"command\":\"npx\",\"args\":[\"-y\",\"vercel-mcp-server\"],\"env\":{\"VERCEL_API_TOKEN\":\"$VERCEL_TOKEN\"}}"
-            fi
-
-            if [ -n "$SERVERS" ]; then
-                MCP_CONFIG="$MCP_CONFIG$SERVERS}}"
-
-                if [ -f "$GEMINI_SETTINGS" ]; then
-                    # Merge with existing settings if jq available
-                    if command -v jq &> /dev/null; then
-                        jq -s '.[0] * .[1]' "$GEMINI_SETTINGS" <(echo "$MCP_CONFIG") > "${GEMINI_SETTINGS}.tmp" && mv "${GEMINI_SETTINGS}.tmp" "$GEMINI_SETTINGS"
-                    else
-                        echo "$MCP_CONFIG" > "$GEMINI_SETTINGS"
-                    fi
-                else
-                    echo "$MCP_CONFIG" > "$GEMINI_SETTINGS"
-                fi
-                echo -e "  $CHECK MCP servers configured in ~/.gemini/settings.json"
-            fi
-            ;;
-    esac
+print_banner() {
+  if [ -t 1 ]; then clear; fi
+  printf "%b\n" "${CYAN}"
+  printf '%s\n' '    ____'
+  printf '%s\n' '   / __ \___  ______________  ____  ____ _'
+  printf '%s\n' '  / /_/ / _ \/ ___/ ___/ __ \/ __ \/ __ `/'
+  printf '%s\n' ' / ____/  __/ /  (__  ) /_/ / / / / /_/ /'
+  printf '%s\n' '/_/    \___/_/  /____/\____/_/ /_/\__,_/'
+  printf "%b\n\n" "${NC}"
+  printf "%b\n" "${BOLD}A starter kit for a portfolio that feels like you${NC}"
+  printf "%b\n\n" "${DIM}Configure locally, then build with your preferred coding agent.${NC}"
 }
 
-# CLI-specific setup
-case "$CLI_TOOL" in
-    "claude-code")
-        # Auto-configure Claude settings (inline)
-        if [ ! -f "$HOME/.claude/settings.json" ] || ! grep -q "autoApproveTools" "$HOME/.claude/settings.json" 2>/dev/null; then
-            echo -e "  Configuring auto-approval..."
-            mkdir -p "$HOME/.claude"
-            SETTINGS_FILE="$HOME/.claude/settings.json"
-            if [ -f "$SETTINGS_FILE" ]; then
-                if command -v jq &> /dev/null; then
-                    jq '. + {"autoApproveTools": ["web_fetch", "web_search"]}' "$SETTINGS_FILE" > "${SETTINGS_FILE}.tmp" && mv "${SETTINGS_FILE}.tmp" "$SETTINGS_FILE"
-                fi
-            else
-                echo '{"autoApproveTools": ["web_fetch", "web_search"]}' > "$SETTINGS_FILE"
-            fi
-            echo -e "  $CHECK Web search and fetch enabled"
-        fi
+check_requirements() {
+  printf "%b\n\n" "${BOLD}Checking requirements...${NC}"
 
-        # Check for existing MCP servers
-        EXISTING_MCPS=$(claude mcp list 2>/dev/null || echo "")
-        if echo "$EXISTING_MCPS" | grep -qi "vercel" && echo "$EXISTING_MCPS" | grep -qi "github"; then
-            echo -e "  $CHECK MCP servers configured (GitHub + Vercel)"
-        else
-            setup_mcp "claude-code"
-        fi
-        echo ""
-        ;;
-    "codex")
-        # Check for existing MCP servers
-        EXISTING_MCPS=$(codex mcp list 2>/dev/null || echo "")
-        if echo "$EXISTING_MCPS" | grep -qi "vercel" && echo "$EXISTING_MCPS" | grep -qi "github"; then
-            echo -e "  $CHECK MCP servers configured (GitHub + Vercel)"
-        else
-            setup_mcp "codex"
-        fi
-        echo ""
-        ;;
-    "gemini")
-        # Check for existing MCP config
-        if [ -f "$HOME/.gemini/settings.json" ] && grep -q "mcpServers" "$HOME/.gemini/settings.json" 2>/dev/null; then
-            echo -e "  $CHECK MCP servers configured"
-        else
-            setup_mcp "gemini"
-        fi
-        echo ""
-        ;;
+  if ! command -v node >/dev/null 2>&1; then
+    printf "  %b Node.js is not installed\n" "$CROSS"
+    printf "  Install Node.js %s.%s or newer: https://nodejs.org/\n" "$MIN_NODE_MAJOR" "$MIN_NODE_MINOR"
+    return 1
+  fi
+
+  local node_version node_major node_minor
+  node_version="$(node --version | sed 's/^v//')"
+  node_major="${node_version%%.*}"
+  node_minor="$(printf '%s' "$node_version" | cut -d. -f2)"
+  if [ "$node_major" -lt "$MIN_NODE_MAJOR" ] || {
+    [ "$node_major" -eq "$MIN_NODE_MAJOR" ] && [ "$node_minor" -lt "$MIN_NODE_MINOR" ];
+  }; then
+    printf "  %b Node.js v%s is too old\n" "$CROSS" "$node_version"
+    printf "  Persona needs Node.js %s.%s or newer.\n" "$MIN_NODE_MAJOR" "$MIN_NODE_MINOR"
+    return 1
+  fi
+  printf "  %b Node.js v%s\n" "$CHECK" "$node_version"
+
+  if ! command -v npm >/dev/null 2>&1; then
+    printf "  %b npm is not installed\n" "$CROSS"
+    return 1
+  fi
+  printf "  %b npm v%s\n" "$CHECK" "$(npm --version)"
+}
+
+if [ "${1:-}" = "--check" ]; then
+  check_requirements
+  printf "%b\n" "${CHECK} Setup preflight passed"
+  exit 0
+fi
+
+print_banner
+check_requirements || exit 1
+
+printf "\n%b\n\n" "${BOLD}Step 1: Your repository${NC}"
+REMOTE_URL="$(git remote get-url origin 2>/dev/null || true)"
+if printf '%s' "$REMOTE_URL" | grep -Eqi 'github\.com[:/]((JacbK)|(jacobkieser))/persona(\.git)?$'; then
+  printf "  %b This copy still points to the Persona template.\n\n" "$YELLOW"
+  printf '%s\n' '  1) Create my portfolio repository with GitHub CLI'
+  printf '%s\n' '  2) Keep this remote for now'
+  read -r -p '  Select [2]: ' repo_choice
+  repo_choice="${repo_choice:-2}"
+
+  if [ "$repo_choice" = "1" ]; then
+    if ! command -v gh >/dev/null 2>&1 || ! gh auth status >/dev/null 2>&1; then
+      printf "  %b GitHub CLI must be installed and signed in first: https://cli.github.com/\n" "$YELLOW"
+      exit 1
+    fi
+
+    read -r -p '  Repository name [my-portfolio]: ' repo_name
+    repo_name="${repo_name:-my-portfolio}"
+    github_owner="$(gh api user --jq .login)"
+    if ! gh repo create "$github_owner/$repo_name" --public; then
+      printf "  %b Could not create the repository. Nothing was changed locally.\n" "$CROSS"
+      exit 1
+    fi
+
+    git remote rename origin persona-template
+    git remote add origin "https://github.com/$github_owner/$repo_name.git"
+    git push -u origin HEAD:main
+    printf "  %b Created github.com/%s/%s\n" "$CHECK" "$github_owner" "$repo_name"
+  else
+    printf "  %b Before publishing, rename the template remote and add your own origin.\n" "$DIM"
+  fi
+else
+  printf "  %b Repository is ready\n" "$CHECK"
+fi
+
+printf "\n%b\n\n" "${BOLD}Step 2: Dependencies${NC}"
+if [ ! -d node_modules ] || ! npm ls --depth=0 >/dev/null 2>&1; then
+  npm install || exit 1
+fi
+printf "  %b Dependencies are ready\n" "$CHECK"
+
+NEED_CONFIG=true
+if [ -f profile.yaml ]; then
+  printf "\n%b\n" "${CHECK} Found profile.yaml"
+  read -r -p '  Keep it? [Y/n]: ' keep_config
+  case "${keep_config:-y}" in
+    n|N) NEED_CONFIG=true ;;
+    *) NEED_CONFIG=false ;;
+  esac
+fi
+
+DEV_PID=""
+cleanup_server() {
+  if [ -n "$DEV_PID" ]; then
+    kill "$DEV_PID" >/dev/null 2>&1 || true
+    wait "$DEV_PID" >/dev/null 2>&1 || true
+  fi
+}
+
+if [ "$NEED_CONFIG" = true ]; then
+  printf "\n%b\n" "${BOLD}Step 3: Tell Persona about you${NC}"
+  rm -f .config-saved
+  npm run dev >/dev/null 2>&1 &
+  DEV_PID=$!
+  trap cleanup_server EXIT INT TERM
+
+  ready=false
+  for _ in $(seq 1 30); do
+    if node -e "fetch('http://127.0.0.1:3000/config').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"; then
+      ready=true
+      break
+    fi
+    sleep 1
+  done
+  if [ "$ready" != true ]; then
+    printf "  %b The local setup page did not start. Run npm run dev to see the error.\n" "$CROSS"
+    exit 1
+  fi
+
+  printf "  Open %bhttp://127.0.0.1:3000/config%b\n" "$CYAN" "$NC"
+  if command -v open >/dev/null 2>&1; then
+    open http://127.0.0.1:3000/config
+  elif command -v xdg-open >/dev/null 2>&1; then
+    xdg-open http://127.0.0.1:3000/config
+  fi
+
+  printf "  Waiting for you to save profile.yaml...\n"
+  while [ ! -f .config-saved ]; do sleep 1; done
+  rm -f .config-saved
+  cleanup_server
+  DEV_PID=""
+  trap - EXIT INT TERM
+  printf "  %b Profile saved\n" "$CHECK"
+fi
+
+if [ ! -f profile.yaml ]; then
+  printf "  %b profile.yaml was not created. Run ./setup.sh again.\n" "$CROSS"
+  exit 1
+fi
+
+printf "\n%b\n\n" "${BOLD}Step 4: Choose your coding agent${NC}"
+printf '%s\n' '  1) Claude Code'
+printf '%s\n' '  2) Gemini CLI'
+printf '%s\n' '  3) Codex'
+printf '%s\n' '  4) Cursor'
+printf '%s\n' '  5) Windsurf'
+printf '%s\n' '  6) Antigravity'
+printf '%s\n' '  7) Other'
+read -r -p '  Select: ' cli_choice
+
+case "$cli_choice" in
+  1) cli_name='Claude Code'; cli_command='claude'; instruction_file='CLAUDE.md' ;;
+  2) cli_name='Gemini CLI'; cli_command='gemini'; instruction_file='GEMINI.md' ;;
+  3) cli_name='Codex'; cli_command='codex'; instruction_file='AGENTS.md' ;;
+  4) cli_name='Cursor'; cli_command='cursor'; instruction_file='.cursorrules' ;;
+  5) cli_name='Windsurf'; cli_command='windsurf'; instruction_file='.agent/persona/SKILL.md' ;;
+  6) cli_name='Antigravity'; cli_command='antigravity'; instruction_file='.antigravity/rules.md' ;;
+  7) cli_name='your coding agent'; cli_command=''; instruction_file='.agent/persona/SKILL.md' ;;
+  *) printf "  %b Choose a number from 1 to 7.\n" "$CROSS"; exit 1 ;;
 esac
 
-# ============================================
-# Step 5: Launch
-# ============================================
+printf "\n  %b Persona does not change global settings or collect access tokens.\n" "$CHECK"
+printf "  %b Instructions: %s\n" "$CHECK" "$instruction_file"
+printf "  Ask %s to: %bBuild my portfolio%b\n" "$cli_name" "$GREEN" "$NC"
 
-echo -e "${BOLD}Ready to Build!${NC}"
-echo ""
-echo -e "  ${GREEN}The AI will:${NC}"
-echo -e "    $ARROW Research you online (GitHub, web)"
-echo -e "    $ARROW Create a unique design based on your preferences"
-echo -e "    $ARROW Build your portfolio from scratch"
-echo -e "    $ARROW Iterate until it meets quality standards"
-echo ""
+if [ -z "$cli_command" ]; then
+  exit 0
+fi
 
-# Launch the appropriate CLI
-cd "$PROJECT_DIR"
+if ! command -v "$cli_command" >/dev/null 2>&1; then
+  printf "\n  %b %s is not installed or is not available in PATH.\n" "$YELLOW" "$cli_name"
+  printf "  Install it from its official site, then run ./setup.sh again.\n"
+  exit 1
+fi
 
-case "$CLI_TOOL" in
-    "claude-code")
-        echo -e "${CYAN}Starting Claude Code...${NC}"
-        echo ""
-        echo -e "  $CHECK Instructions auto-loaded via CLAUDE.md"
-        echo -e "  ${DIM}Just say:${NC} ${GREEN}\"Build my portfolio\"${NC}"
-        echo ""
-        read -p "Press Enter to launch Claude..."
-        exec claude
-        ;;
-
-    "codex")
-        echo -e "${CYAN}Starting Codex...${NC}"
-        echo ""
-        echo -e "  $CHECK Instructions auto-loaded via AGENTS.md"
-        echo -e "  ${DIM}Just say:${NC} ${GREEN}\"Build my portfolio\"${NC}"
-        echo ""
-        read -p "Press Enter to launch Codex..."
-        exec codex
-        ;;
-
-    "gemini")
-        echo -e "${CYAN}Starting Google Gemini CLI...${NC}"
-        echo ""
-        echo -e "  $CHECK Instructions auto-loaded via GEMINI.md"
-        echo -e "  ${DIM}Just say:${NC} ${GREEN}\"Build my portfolio\"${NC}"
-        echo ""
-        read -p "Press Enter to launch Gemini..."
-        exec gemini
-        ;;
-
-    "cursor")
-        echo -e "${CYAN}Opening Cursor...${NC}"
-        echo ""
-        echo -e "  $CHECK Instructions auto-loaded via .cursorrules"
-        echo -e "  ${DIM}Just say:${NC} ${GREEN}\"Build my portfolio\"${NC}"
-        echo ""
-        if command -v cursor &> /dev/null; then
-            cursor "$PROJECT_DIR"
-        else
-            echo -e "  ${YELLOW}Cursor not in PATH. Open the project manually.${NC}"
-        fi
-        ;;
-
-    "windsurf")
-        echo -e "${CYAN}Opening Windsurf...${NC}"
-        echo ""
-        echo -e "  ${DIM}Windsurf requires manual setup:${NC}"
-        echo -e "    1. Open this project in Windsurf"
-        echo -e "    2. Say: ${GREEN}\"Read .agent/persona/SKILL.md and build my portfolio\"${NC}"
-        echo ""
-        if command -v windsurf &> /dev/null; then
-            windsurf "$PROJECT_DIR"
-        else
-            echo -e "  ${YELLOW}Windsurf not in PATH. Open the project manually.${NC}"
-        fi
-        ;;
-
-    "antigravity")
-        echo -e "${CYAN}Opening Google Antigravity...${NC}"
-        echo ""
-        echo -e "  $CHECK Instructions auto-loaded via .antigravity/rules.md"
-        echo -e "  ${DIM}Just say:${NC} ${GREEN}\"Build my portfolio\"${NC}"
-        echo ""
-        if command -v antigravity &> /dev/null; then
-            antigravity "$PROJECT_DIR"
-        else
-            echo -e "  ${YELLOW}Antigravity not in PATH. Open the project manually.${NC}"
-        fi
-        ;;
-
-    "other"|*)
-        echo -e "${YELLOW}Custom CLI selected${NC}"
-        echo ""
-        echo -e "  ${DIM}To use your AI tool:${NC}"
-        echo -e "    1. Launch your preferred AI coding assistant"
-        echo -e "    2. Open this project: ${CYAN}$PROJECT_DIR${NC}"
-        echo -e "    3. Say: ${GREEN}'Read .agent/persona/SKILL.md and build my portfolio'${NC}"
-        echo ""
-        ;;
-esac
+read -r -p "  Press Enter to open $cli_name..."
+if [ "$cli_command" = 'cursor' ] || [ "$cli_command" = 'windsurf' ] || [ "$cli_command" = 'antigravity' ]; then
+  "$cli_command" "$PROJECT_DIR"
+else
+  exec "$cli_command"
+fi

--- a/src/app/api/read-config/route.ts
+++ b/src/app/api/read-config/route.ts
@@ -1,9 +1,14 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
+import { isLocalSetupRequest, LOCAL_ONLY_RESPONSE } from '@/lib/local-setup';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  if (!isLocalSetupRequest(request)) {
+    return NextResponse.json(LOCAL_ONLY_RESPONSE, { status: 404 });
+  }
+
   try {
     const configPath = join(process.cwd(), 'profile.yaml');
     const fileContents = await readFile(configPath, 'utf-8');

--- a/src/app/api/save-config/route.ts
+++ b/src/app/api/save-config/route.ts
@@ -1,44 +1,52 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { writeFile, access, constants } from 'fs/promises';
 import { join, dirname } from 'path';
+import * as yamlParser from 'js-yaml';
+import { isLocalSetupRequest, LOCAL_ONLY_RESPONSE } from '@/lib/local-setup';
+
+const MAX_CONFIG_BYTES = 256 * 1024;
 
 export async function POST(request: NextRequest) {
+  if (!isLocalSetupRequest(request)) {
+    return NextResponse.json(LOCAL_ONLY_RESPONSE, { status: 404 });
+  }
+
   try {
     const { yaml } = await request.json();
 
-    if (!yaml || typeof yaml !== 'string') {
+    if (!yaml || typeof yaml !== 'string' || Buffer.byteLength(yaml, 'utf8') > MAX_CONFIG_BYTES) {
       return NextResponse.json({ error: 'Invalid YAML content' }, { status: 400 });
+    }
+
+    try {
+      const parsed = yamlParser.load(yaml);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new Error('Profile must be a YAML object');
+      }
+    } catch {
+      return NextResponse.json({ error: 'YAML could not be parsed' }, { status: 400 });
     }
 
     // Write to project root
     const filePath = join(process.cwd(), 'profile.yaml');
     const dir = dirname(filePath);
 
-    console.log('[save-config] Attempting to write to:', filePath);
-    console.log('[save-config] Directory:', dir);
-    console.log('[save-config] YAML length:', yaml.length);
-
     // Check if directory is writable
     try {
       await access(dir, constants.W_OK);
-      console.log('[save-config] Directory is writable');
     } catch {
-      console.error('[save-config] Directory is NOT writable:', dir);
-      return NextResponse.json({ error: `Directory not writable: ${dir}` }, { status: 500 });
+      return NextResponse.json({ error: 'Project directory is not writable' }, { status: 500 });
     }
 
     await writeFile(filePath, yaml, 'utf-8');
-    console.log('[save-config] Successfully wrote file');
 
     // Write sentinel file for setup.sh to detect save completion
     const sentinelPath = join(process.cwd(), '.config-saved');
     await writeFile(sentinelPath, new Date().toISOString(), 'utf-8');
-    console.log('[save-config] Wrote sentinel file');
 
-    return NextResponse.json({ success: true, path: filePath });
+    return NextResponse.json({ success: true, path: 'profile.yaml' });
   } catch (error) {
     console.error('[save-config] Failed to save profile.yaml:', error);
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    return NextResponse.json({ error: `Failed to write file: ${errorMessage}` }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to write profile.yaml' }, { status: 500 });
   }
 }

--- a/src/app/api/upload-material/route.ts
+++ b/src/app/api/upload-material/route.ts
@@ -1,15 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { writeFile, mkdir } from 'fs/promises';
+import { writeFile, mkdir, unlink } from 'fs/promises';
 import { join } from 'path';
 import PDFParser from 'pdf2json';
+import { isLocalSetupRequest, LOCAL_ONLY_RESPONSE } from '@/lib/local-setup';
+import {
+  MaterialFolder,
+  sanitizeMaterialName,
+  validateMaterialUpload,
+} from '@/lib/material-upload';
 
 // Extract text from PDF buffer using pdf2json
 async function extractPdfText(buffer: Buffer): Promise<string> {
   return new Promise((resolve, reject) => {
     const pdfParser = new PDFParser();
 
-    pdfParser.on('pdfParser_dataError', (errData: { parserError: Error }) => {
-      reject(errData.parserError);
+    pdfParser.on('pdfParser_dataError', (errData: Error | { parserError: Error }) => {
+      reject(errData instanceof Error ? errData : errData.parserError);
     });
 
     pdfParser.on('pdfParser_dataReady', (pdfData: { Pages?: Array<{ Texts?: Array<{ R?: Array<{ T?: string }> }> }> }) => {
@@ -32,17 +38,28 @@ async function extractPdfText(buffer: Buffer): Promise<string> {
 }
 
 export async function POST(request: NextRequest) {
+  if (!isLocalSetupRequest(request)) {
+    return NextResponse.json(LOCAL_ONLY_RESPONSE, { status: 404 });
+  }
+
   try {
     const formData = await request.formData();
     const file = formData.get('file') as File | null;
     const folder = formData.get('folder') as string | null;
 
-    if (!file) {
+    if (!file || (folder !== 'documents' && folder !== 'images')) {
       return NextResponse.json({ error: 'No file provided' }, { status: 400 });
     }
 
-    // Determine target folder (documents or images)
-    const targetFolder = folder === 'images' ? 'images' : 'documents';
+    const targetFolder: MaterialFolder = folder;
+    let safeName: string;
+    try {
+      safeName = validateMaterialUpload(file, targetFolder);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Invalid file';
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+
     const materialsPath = join(process.cwd(), 'materials', targetFolder);
 
     // Ensure directory exists
@@ -52,8 +69,6 @@ export async function POST(request: NextRequest) {
     const bytes = await file.arrayBuffer();
     const buffer = Buffer.from(bytes);
 
-    // Sanitize filename
-    const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_');
     const filePath = join(materialsPath, safeName);
 
     await writeFile(filePath, buffer);
@@ -84,5 +99,45 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error('Failed to upload file:', error);
     return NextResponse.json({ error: 'Failed to upload file' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  if (!isLocalSetupRequest(request)) {
+    return NextResponse.json(LOCAL_ONLY_RESPONSE, { status: 404 });
+  }
+
+  try {
+    const { path } = (await request.json()) as { path?: unknown };
+    if (typeof path !== 'string') {
+      return NextResponse.json({ error: 'Invalid material path' }, { status: 400 });
+    }
+
+    const match = path.match(/^materials\/(documents|images)\/([^/]+)$/);
+    if (!match) {
+      return NextResponse.json({ error: 'Invalid material path' }, { status: 400 });
+    }
+
+    const folder = match[1] as MaterialFolder;
+    const safeName = sanitizeMaterialName(match[2]);
+    if (safeName !== match[2]) {
+      return NextResponse.json({ error: 'Invalid material path' }, { status: 400 });
+    }
+
+    await unlink(join(process.cwd(), 'materials', folder, safeName));
+
+    if (safeName.toLowerCase().endsWith('.pdf')) {
+      const textName = safeName.replace(/\.pdf$/i, '.txt');
+      await unlink(join(process.cwd(), 'materials', folder, textName)).catch(() => undefined);
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    const code = error && typeof error === 'object' && 'code' in error ? error.code : undefined;
+    if (code === 'ENOENT') {
+      return NextResponse.json({ error: 'Material not found' }, { status: 404 });
+    }
+    console.error('Failed to delete material:', error);
+    return NextResponse.json({ error: 'Failed to delete material' }, { status: 500 });
   }
 }

--- a/src/app/config/inspirations.ts
+++ b/src/app/config/inspirations.ts
@@ -1,0 +1,287 @@
+import type { InspirationArchetype } from "@/lib/profile-config";
+
+
+export const ARCHETYPE_EXAMPLES = [
+  {
+    id: 1,
+    name: 'Brutalist',
+    description: 'Sharp edges, monospace, high contrast',
+    color: 'from-neutral-900 to-neutral-800',
+    examples: [
+      {
+        name: 'Brutalist Web Design',
+        url: 'https://brutalist-web.design',
+        screenshot: '/inspirations/brutalist-web-design.png',
+        design: {
+          typography: 'System monospace, no custom fonts, 16px base',
+          colors: 'Pure black/white, no grays, high contrast',
+          layout: 'Single column, left-aligned, no grid, HTML default flow',
+          spacing: 'Minimal padding, browser defaults, dense',
+          motion: 'None - completely static',
+          details: 'No shadows, underlined links, raw HTML aesthetic'
+        }
+      },
+      {
+        name: 'Neobrutalism',
+        url: 'https://neobrutalism.dev',
+        screenshot: '/inspirations/neobrutalism.png',
+        design: {
+          typography: 'Bold sans-serif headers (800+ weight), monospace body',
+          colors: 'Black backgrounds, white text, neon accent (yellow/cyan)',
+          layout: 'Boxy cards, thick borders (4-8px), no border-radius',
+          spacing: 'Generous padding (24-48px), clear sections',
+          motion: 'Sharp snap animations, no easing curves',
+          details: 'Heavy drop shadows (8-12px), stark borders, grid-based'
+        }
+      },
+      {
+        name: 'Mono Company',
+        url: 'https://mono.company',
+        screenshot: '/inspirations/mono-company.png',
+        design: {
+          typography: 'Monospace everywhere (IBM Plex Mono), 14-16px',
+          colors: 'True monochrome (black/white/grays), no color',
+          layout: 'Fixed-width (1200px max), centered, strict grid',
+          spacing: 'Consistent 8px grid, mathematical spacing',
+          motion: 'Minimal hover states, fade transitions only',
+          details: 'Thin borders (1px), subtle shadows, pixel-perfect alignment'
+        }
+      },
+    ],
+  },
+  {
+    id: 2,
+    name: 'Editorial',
+    description: 'Magazine layouts, serif headers',
+    color: 'from-amber-900 to-amber-800',
+    examples: [
+      {
+        name: 'NY Times',
+        url: 'https://www.nytimes.com',
+        screenshot: '/inspirations/nytimes.png',
+        design: {
+          typography: 'Georgia/Serif headers (28-48px), Sans body (16-18px)',
+          colors: 'Black text, white bg, minimal red accents',
+          layout: 'Multi-column grid, asymmetric breakup, sidebars',
+          spacing: 'Tight line-height (1.4), dense paragraph spacing',
+          motion: 'None - static content focus',
+          details: 'Thin divider lines (1px), occasional images, text-heavy'
+        }
+      },
+      {
+        name: 'The Pudding',
+        url: 'https://pudding.cool',
+        screenshot: '/inspirations/pudding.png',
+        design: {
+          typography: 'Bold serif headlines (60-80px), sans body (18-21px)',
+          colors: 'Vibrant accent colors, white/cream backgrounds',
+          layout: 'Asymmetric columns (70/30 split), overlapping elements',
+          spacing: 'Generous (100-200px section gaps), breathable',
+          motion: 'Scroll-triggered animations, data visualizations',
+          details: 'Large pull quotes, colored text blocks, image/text overlap'
+        }
+      },
+      {
+        name: 'The Verge',
+        url: 'https://www.theverge.com',
+        screenshot: '/inspirations/theverge.png',
+        design: {
+          typography: '__Optimist/serif headlines (32-56px), sans body (17px)',
+          colors: 'Black/white base, neon accent (hot pink/lime)',
+          layout: 'Card-based grid, featured hero, sidebar modules',
+          spacing: 'Moderate (40-60px gaps), card padding (24px)',
+          motion: 'Smooth image lazy-loads, hover scale effects',
+          details: 'Rounded cards (8px), soft shadows, category tags'
+        }
+      },
+    ],
+  },
+  {
+    id: 3,
+    name: 'Terminal',
+    description: 'Command-line aesthetic, CRT colors',
+    color: 'from-green-900 to-green-800',
+    examples: [
+      {
+        name: 'Terminal Sexy',
+        url: 'https://terminal.sexy',
+        screenshot: '/inspirations/terminal-sexy.png',
+        design: {
+          typography: 'Monospace (Fira Code/JetBrains), 14px fixed',
+          colors: 'Dark bg (#0d0d0d), green text (#00ff41), cursor blink',
+          layout: 'Fixed-width (80ch), single column, text-only',
+          spacing: 'Line-height 1.5, no padding, terminal default',
+          motion: 'Blinking cursor, typewriter effect on load',
+          details: 'ASCII borders, prompt symbols (>), CRT scanlines'
+        }
+      },
+      {
+        name: 'Robin Sloan',
+        url: 'https://www.robinsloan.com',
+        screenshot: '/inspirations/robin-sloan.png',
+        design: {
+          typography: 'Monospace (Courier/Consolas), 16px, serif fallback',
+          colors: 'Black bg, white text, no colors',
+          layout: 'Narrow column (60ch), left-aligned, essay format',
+          spacing: 'Generous line-height (1.8), wide margins',
+          motion: 'None - reading-focused',
+          details: 'Underlined links, minimal decoration, text-first'
+        }
+      },
+      {
+        name: 'GitHub',
+        url: 'https://github.com',
+        screenshot: '/inspirations/github.png',
+        design: {
+          typography: 'Monospace code (SF Mono), sans UI (14px)',
+          colors: 'Dark mode (#0d1117), white text, blue accents',
+          layout: 'File tree sidebar, content main, 3-column',
+          spacing: 'Compact (8-16px gaps), dense information',
+          motion: 'Instant transitions, no delays',
+          details: 'Syntax highlighting, line numbers, code blocks'
+        }
+      },
+    ],
+  },
+  {
+    id: 4,
+    name: 'Retro Arcade',
+    description: 'Pixel fonts, neon colors, 8-bit',
+    color: 'from-fuchsia-900 to-purple-900',
+    examples: [
+      {
+        name: 'Poolsuite',
+        url: 'https://poolsuite.net',
+        screenshot: '/inspirations/poolsuite.png',
+        design: {
+          typography: 'Rounded sans (Comic Sans-adjacent), 16-20px, playful',
+          colors: 'Pastel (pink/blue/yellow), gradients, retro palette',
+          layout: 'Centered cards, floating elements, sticker aesthetic',
+          spacing: 'Varied (24-80px), playful asymmetry',
+          motion: 'Wobble animations, parallax scrolling, float effects',
+          details: 'Soft shadows, rounded corners (16-24px), illustrations'
+        }
+      },
+      {
+        name: 'Bruno Simon',
+        url: 'https://bruno-simon.com',
+        screenshot: '/inspirations/bruno-simon.png',
+        design: {
+          typography: 'Bold sans-serif, 14-18px, clean UI',
+          colors: 'Dark bg, white text, colorful 3D elements',
+          layout: '3D canvas full-screen, minimal UI overlay',
+          spacing: 'UI elements: compact (12-16px), spacious canvas',
+          motion: '3D physics, interactive elements, smooth 60fps',
+          details: 'WebGL rendering, car/road metaphor, gamified'
+        }
+      },
+      {
+        name: 'Windows 93',
+        url: 'https://www.windows93.net',
+        screenshot: '/inspirations/windows93.png',
+        design: {
+          typography: 'Pixel font (Press Start 2P), 8-12px, bitmap',
+          colors: 'Neon (magenta/cyan/yellow), black bg, high saturation',
+          layout: 'OS window metaphor, draggable windows, desktop UI',
+          spacing: 'Pixelated 8px grid, retro OS spacing',
+          motion: 'Glitch effects, cursor trails, animated backgrounds',
+          details: 'Pixel art icons, window chrome, 90s nostalgia'
+        }
+      },
+    ],
+  },
+  {
+    id: 5,
+    name: 'Geometric',
+    description: 'Color blocking, shapes, bold',
+    color: 'from-blue-900 to-blue-800',
+    examples: [
+      {
+        name: 'Linear',
+        url: 'https://linear.app',
+        screenshot: '/inspirations/linear.png',
+        design: {
+          typography: 'Inter/SF Pro, 14-16px, -0.02em tracking, 500 weight',
+          colors: 'True black (#000), white (#fff), purple accent (#5e6ad2)',
+          layout: 'Centered, max-width 1200px, symmetric grid',
+          spacing: 'Generous (80-120px sections), 40px padding',
+          motion: 'Subtle fades (200ms), smooth scroll, polished',
+          details: 'No borders, soft gradients, clean edges, minimal'
+        }
+      },
+      {
+        name: 'Stripe',
+        url: 'https://stripe.com',
+        screenshot: '/inspirations/stripe.png',
+        design: {
+          typography: 'Camphor/sans-serif, 16-18px, medium weight',
+          colors: 'White bg, black text, blue (#635bff) accent',
+          layout: 'Asymmetric hero, grid-based content, diagonal dividers',
+          spacing: 'Variable (60-100px), responsive scaling',
+          motion: 'Animated gradients, smooth scroll reveals',
+          details: 'Gradient meshes, geometric shapes, depth layers'
+        }
+      },
+      {
+        name: 'Vercel',
+        url: 'https://vercel.com',
+        screenshot: '/inspirations/vercel.png',
+        design: {
+          typography: 'Geist/mono hybrid, 14-16px, tight spacing',
+          colors: 'True black (#000), white (#fff), no color',
+          layout: 'Full-width sections, edge-to-edge, no max-width',
+          spacing: 'Extreme (120-200px section gaps), minimal padding',
+          motion: 'Fast (100ms), instant feedback, no delays',
+          details: 'Thin borders (1px), sharp corners, monochromatic'
+        }
+      },
+    ],
+  },
+  {
+    id: 6,
+    name: 'Luxury',
+    description: 'Elegant serifs, large whitespace',
+    color: 'from-stone-900 to-stone-800',
+    examples: [
+      {
+        name: 'Apple',
+        url: 'https://www.apple.com',
+        screenshot: '/inspirations/apple.png',
+        design: {
+          typography: 'SF Pro Display, 21-80px headlines, light/medium weights',
+          colors: 'White bg, black text, minimal color (product images)',
+          layout: 'Large hero images, centered text, single column flow',
+          spacing: 'Massive (150-300px gaps), generous padding',
+          motion: 'Smooth scrollytelling, parallax, video backgrounds',
+          details: 'High-res images, soft shadows, rounded corners (12px)'
+        }
+      },
+      {
+        name: 'Rolex',
+        url: 'https://www.rolex.com',
+        screenshot: '/inspirations/rolex.png',
+        design: {
+          typography: 'Serif headers (28-48px), light sans body (14-16px)',
+          colors: 'Black/white/gold (#d4af37), minimal palette',
+          layout: 'Narrow column (700px), centered, ample margins',
+          spacing: 'Luxurious (100-200px), single element focus',
+          motion: 'Slow fades (600ms), elegant transitions',
+          details: 'Elegant dividers, gold accents, serif details'
+        }
+      },
+      {
+        name: 'Bottega Veneta',
+        url: 'https://www.bottegaveneta.com',
+        screenshot: '/inspirations/bottega-veneta.png',
+        design: {
+          typography: 'Light serif (300 weight), 18-24px, letter-spacing +0.05em',
+          colors: 'Cream/beige bg, black text, earth tones',
+          layout: 'Image-first, minimal text overlay, editorial flow',
+          spacing: 'Extreme whitespace (200-400px), breathing room',
+          motion: 'Slow reveals (800ms), lazy image loads',
+          details: 'Thin borders, elegant typography, refined aesthetic'
+        }
+      },
+    ],
+  },
+] satisfies InspirationArchetype[];

--- a/src/app/config/layout.tsx
+++ b/src/app/config/layout.tsx
@@ -1,0 +1,9 @@
+import { notFound } from "next/navigation";
+
+export default function ConfigLayout({ children }: { children: React.ReactNode }) {
+  if (process.env.NODE_ENV === "production") {
+    notFound();
+  }
+
+  return children;
+}

--- a/src/app/config/page.tsx
+++ b/src/app/config/page.tsx
@@ -442,7 +442,7 @@ export default function ConfigPage() {
                     <option value="gemini">Google Gemini CLI</option>
                     <option value="aider">Aider</option>
                     <option value="cursor">Cursor AI</option>
-                    <option value="windsurf">Windsurf</option>
+                    <option value="devin">Devin CLI</option>
                     <option value="antigravity">Antigravity</option>
                     <option value="other">Other / Custom</option>
                   </select>

--- a/src/app/config/page.tsx
+++ b/src/app/config/page.tsx
@@ -1,298 +1,17 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
-import { ArrowLeft, Download, Sparkles, Upload, FileText, Image, X, Check, Terminal, ArrowRight, ChevronRight, Loader2, Edit3 } from 'lucide-react';
+import { useState, useEffect } from 'react';
+import { ArrowLeft, Download, Sparkles, Upload, FileText, Image as ImageIcon, X, Check, Terminal, ArrowRight, ChevronRight, Loader2, Edit3 } from 'lucide-react';
 import Link from 'next/link';
+import Image from 'next/image';
+import { ARCHETYPE_EXAMPLES } from './inspirations';
+import { generateProfileYaml, type ProfileConfig } from '@/lib/profile-config';
 
 type ConfigStep = 'basics' | 'design' | 'review';
 
-const ARCHETYPE_EXAMPLES = [
-  {
-    id: 1,
-    name: 'Brutalist',
-    description: 'Sharp edges, monospace, high contrast',
-    color: 'from-neutral-900 to-neutral-800',
-    examples: [
-      {
-        name: 'Brutalist Web Design',
-        url: 'https://brutalist-web.design',
-        screenshot: '/inspirations/brutalist-web-design.png',
-        design: {
-          typography: 'System monospace, no custom fonts, 16px base',
-          colors: 'Pure black/white, no grays, high contrast',
-          layout: 'Single column, left-aligned, no grid, HTML default flow',
-          spacing: 'Minimal padding, browser defaults, dense',
-          motion: 'None - completely static',
-          details: 'No shadows, underlined links, raw HTML aesthetic'
-        }
-      },
-      {
-        name: 'Neobrutalism',
-        url: 'https://neobrutalism.dev',
-        screenshot: '/inspirations/neobrutalism.png',
-        design: {
-          typography: 'Bold sans-serif headers (800+ weight), monospace body',
-          colors: 'Black backgrounds, white text, neon accent (yellow/cyan)',
-          layout: 'Boxy cards, thick borders (4-8px), no border-radius',
-          spacing: 'Generous padding (24-48px), clear sections',
-          motion: 'Sharp snap animations, no easing curves',
-          details: 'Heavy drop shadows (8-12px), stark borders, grid-based'
-        }
-      },
-      {
-        name: 'Mono Company',
-        url: 'https://mono.company',
-        screenshot: '/inspirations/mono-company.png',
-        design: {
-          typography: 'Monospace everywhere (IBM Plex Mono), 14-16px',
-          colors: 'True monochrome (black/white/grays), no color',
-          layout: 'Fixed-width (1200px max), centered, strict grid',
-          spacing: 'Consistent 8px grid, mathematical spacing',
-          motion: 'Minimal hover states, fade transitions only',
-          details: 'Thin borders (1px), subtle shadows, pixel-perfect alignment'
-        }
-      },
-    ],
-  },
-  {
-    id: 2,
-    name: 'Editorial',
-    description: 'Magazine layouts, serif headers',
-    color: 'from-amber-900 to-amber-800',
-    examples: [
-      {
-        name: 'NY Times',
-        url: 'https://www.nytimes.com',
-        screenshot: '/inspirations/nytimes.png',
-        design: {
-          typography: 'Georgia/Serif headers (28-48px), Sans body (16-18px)',
-          colors: 'Black text, white bg, minimal red accents',
-          layout: 'Multi-column grid, asymmetric breakup, sidebars',
-          spacing: 'Tight line-height (1.4), dense paragraph spacing',
-          motion: 'None - static content focus',
-          details: 'Thin divider lines (1px), occasional images, text-heavy'
-        }
-      },
-      {
-        name: 'The Pudding',
-        url: 'https://pudding.cool',
-        screenshot: '/inspirations/pudding.png',
-        design: {
-          typography: 'Bold serif headlines (60-80px), sans body (18-21px)',
-          colors: 'Vibrant accent colors, white/cream backgrounds',
-          layout: 'Asymmetric columns (70/30 split), overlapping elements',
-          spacing: 'Generous (100-200px section gaps), breathable',
-          motion: 'Scroll-triggered animations, data visualizations',
-          details: 'Large pull quotes, colored text blocks, image/text overlap'
-        }
-      },
-      {
-        name: 'The Verge',
-        url: 'https://www.theverge.com',
-        screenshot: '/inspirations/theverge.png',
-        design: {
-          typography: '__Optimist/serif headlines (32-56px), sans body (17px)',
-          colors: 'Black/white base, neon accent (hot pink/lime)',
-          layout: 'Card-based grid, featured hero, sidebar modules',
-          spacing: 'Moderate (40-60px gaps), card padding (24px)',
-          motion: 'Smooth image lazy-loads, hover scale effects',
-          details: 'Rounded cards (8px), soft shadows, category tags'
-        }
-      },
-    ],
-  },
-  {
-    id: 3,
-    name: 'Terminal',
-    description: 'Command-line aesthetic, CRT colors',
-    color: 'from-green-900 to-green-800',
-    examples: [
-      {
-        name: 'Terminal Sexy',
-        url: 'https://terminal.sexy',
-        screenshot: '/inspirations/terminal-sexy.png',
-        design: {
-          typography: 'Monospace (Fira Code/JetBrains), 14px fixed',
-          colors: 'Dark bg (#0d0d0d), green text (#00ff41), cursor blink',
-          layout: 'Fixed-width (80ch), single column, text-only',
-          spacing: 'Line-height 1.5, no padding, terminal default',
-          motion: 'Blinking cursor, typewriter effect on load',
-          details: 'ASCII borders, prompt symbols (>), CRT scanlines'
-        }
-      },
-      {
-        name: 'Robin Sloan',
-        url: 'https://www.robinsloan.com',
-        screenshot: '/inspirations/robin-sloan.png',
-        design: {
-          typography: 'Monospace (Courier/Consolas), 16px, serif fallback',
-          colors: 'Black bg, white text, no colors',
-          layout: 'Narrow column (60ch), left-aligned, essay format',
-          spacing: 'Generous line-height (1.8), wide margins',
-          motion: 'None - reading-focused',
-          details: 'Underlined links, minimal decoration, text-first'
-        }
-      },
-      {
-        name: 'GitHub',
-        url: 'https://github.com',
-        screenshot: '/inspirations/github.png',
-        design: {
-          typography: 'Monospace code (SF Mono), sans UI (14px)',
-          colors: 'Dark mode (#0d1117), white text, blue accents',
-          layout: 'File tree sidebar, content main, 3-column',
-          spacing: 'Compact (8-16px gaps), dense information',
-          motion: 'Instant transitions, no delays',
-          details: 'Syntax highlighting, line numbers, code blocks'
-        }
-      },
-    ],
-  },
-  {
-    id: 4,
-    name: 'Retro Arcade',
-    description: 'Pixel fonts, neon colors, 8-bit',
-    color: 'from-fuchsia-900 to-purple-900',
-    examples: [
-      {
-        name: 'Poolsuite',
-        url: 'https://poolsuite.net',
-        screenshot: '/inspirations/poolsuite.png',
-        design: {
-          typography: 'Rounded sans (Comic Sans-adjacent), 16-20px, playful',
-          colors: 'Pastel (pink/blue/yellow), gradients, retro palette',
-          layout: 'Centered cards, floating elements, sticker aesthetic',
-          spacing: 'Varied (24-80px), playful asymmetry',
-          motion: 'Wobble animations, parallax scrolling, float effects',
-          details: 'Soft shadows, rounded corners (16-24px), illustrations'
-        }
-      },
-      {
-        name: 'Bruno Simon',
-        url: 'https://bruno-simon.com',
-        screenshot: '/inspirations/bruno-simon.png',
-        design: {
-          typography: 'Bold sans-serif, 14-18px, clean UI',
-          colors: 'Dark bg, white text, colorful 3D elements',
-          layout: '3D canvas full-screen, minimal UI overlay',
-          spacing: 'UI elements: compact (12-16px), spacious canvas',
-          motion: '3D physics, interactive elements, smooth 60fps',
-          details: 'WebGL rendering, car/road metaphor, gamified'
-        }
-      },
-      {
-        name: 'Windows 93',
-        url: 'https://www.windows93.net',
-        screenshot: '/inspirations/windows93.png',
-        design: {
-          typography: 'Pixel font (Press Start 2P), 8-12px, bitmap',
-          colors: 'Neon (magenta/cyan/yellow), black bg, high saturation',
-          layout: 'OS window metaphor, draggable windows, desktop UI',
-          spacing: 'Pixelated 8px grid, retro OS spacing',
-          motion: 'Glitch effects, cursor trails, animated backgrounds',
-          details: 'Pixel art icons, window chrome, 90s nostalgia'
-        }
-      },
-    ],
-  },
-  {
-    id: 5,
-    name: 'Geometric',
-    description: 'Color blocking, shapes, bold',
-    color: 'from-blue-900 to-blue-800',
-    examples: [
-      {
-        name: 'Linear',
-        url: 'https://linear.app',
-        screenshot: '/inspirations/linear.png',
-        design: {
-          typography: 'Inter/SF Pro, 14-16px, -0.02em tracking, 500 weight',
-          colors: 'True black (#000), white (#fff), purple accent (#5e6ad2)',
-          layout: 'Centered, max-width 1200px, symmetric grid',
-          spacing: 'Generous (80-120px sections), 40px padding',
-          motion: 'Subtle fades (200ms), smooth scroll, polished',
-          details: 'No borders, soft gradients, clean edges, minimal'
-        }
-      },
-      {
-        name: 'Stripe',
-        url: 'https://stripe.com',
-        screenshot: '/inspirations/stripe.png',
-        design: {
-          typography: 'Camphor/sans-serif, 16-18px, medium weight',
-          colors: 'White bg, black text, blue (#635bff) accent',
-          layout: 'Asymmetric hero, grid-based content, diagonal dividers',
-          spacing: 'Variable (60-100px), responsive scaling',
-          motion: 'Animated gradients, smooth scroll reveals',
-          details: 'Gradient meshes, geometric shapes, depth layers'
-        }
-      },
-      {
-        name: 'Vercel',
-        url: 'https://vercel.com',
-        screenshot: '/inspirations/vercel.png',
-        design: {
-          typography: 'Geist/mono hybrid, 14-16px, tight spacing',
-          colors: 'True black (#000), white (#fff), no color',
-          layout: 'Full-width sections, edge-to-edge, no max-width',
-          spacing: 'Extreme (120-200px section gaps), minimal padding',
-          motion: 'Fast (100ms), instant feedback, no delays',
-          details: 'Thin borders (1px), sharp corners, monochromatic'
-        }
-      },
-    ],
-  },
-  {
-    id: 6,
-    name: 'Luxury',
-    description: 'Elegant serifs, large whitespace',
-    color: 'from-stone-900 to-stone-800',
-    examples: [
-      {
-        name: 'Apple',
-        url: 'https://www.apple.com',
-        screenshot: '/inspirations/apple.png',
-        design: {
-          typography: 'SF Pro Display, 21-80px headlines, light/medium weights',
-          colors: 'White bg, black text, minimal color (product images)',
-          layout: 'Large hero images, centered text, single column flow',
-          spacing: 'Massive (150-300px gaps), generous padding',
-          motion: 'Smooth scrollytelling, parallax, video backgrounds',
-          details: 'High-res images, soft shadows, rounded corners (12px)'
-        }
-      },
-      {
-        name: 'Rolex',
-        url: 'https://www.rolex.com',
-        screenshot: '/inspirations/rolex.png',
-        design: {
-          typography: 'Serif headers (28-48px), light sans body (14-16px)',
-          colors: 'Black/white/gold (#d4af37), minimal palette',
-          layout: 'Narrow column (700px), centered, ample margins',
-          spacing: 'Luxurious (100-200px), single element focus',
-          motion: 'Slow fades (600ms), elegant transitions',
-          details: 'Elegant dividers, gold accents, serif details'
-        }
-      },
-      {
-        name: 'Bottega Veneta',
-        url: 'https://www.bottegaveneta.com',
-        screenshot: '/inspirations/bottega-veneta.png',
-        design: {
-          typography: 'Light serif (300 weight), 18-24px, letter-spacing +0.05em',
-          colors: 'Cream/beige bg, black text, earth tones',
-          layout: 'Image-first, minimal text overlay, editorial flow',
-          spacing: 'Extreme whitespace (200-400px), breathing room',
-          motion: 'Slow reveals (800ms), lazy image loads',
-          details: 'Thin borders, elegant typography, refined aesthetic'
-        }
-      },
-    ],
-  },
-];
 
 export default function ConfigPage() {
-  const [config, setConfig] = useState({
+  const [config, setConfig] = useState<ProfileConfig>({
     name: '',
     email: '',
     github: '',
@@ -335,13 +54,13 @@ export default function ConfigPage() {
   const [selectedExamples, setSelectedExamples] = useState<string[]>([]);
   const [uploadedFiles, setUploadedFiles] = useState<{ name: string; path: string; folder: string }[]>([]);
   const [isUploading, setIsUploading] = useState(false);
+  const [uploadError, setUploadError] = useState('');
   const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [configSaved, setConfigSaved] = useState(false);
   const [showDownloadHelp, setShowDownloadHelp] = useState(false);
   const [currentStep, setCurrentStep] = useState<ConfigStep>('basics');
   const [isLoading, setIsLoading] = useState(true);
   const [hasExistingConfig, setHasExistingConfig] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Load existing config on mount
   useEffect(() => {
@@ -352,6 +71,9 @@ export default function ConfigPage() {
 
         if (data.exists && data.config) {
           const c = data.config;
+          const enabledSections = Array.isArray(c.sections)
+            ? new Set<string>(c.sections)
+            : null;
           setHasExistingConfig(true);
 
           // Populate form with existing values
@@ -364,15 +86,15 @@ export default function ConfigPage() {
             website: c.website || '',
             cli: c.cli || 'claude-code',
             sections: {
-              hero: c.sections?.hero ?? true,
-              about: c.sections?.about ?? true,
-              experience: c.sections?.experience ?? true,
-              projects: c.sections?.projects ?? true,
-              skills: c.sections?.skills ?? false,
-              education: c.sections?.education ?? false,
-              contact: c.sections?.contact ?? true,
-              blog: c.sections?.blog ?? false,
-              testimonials: c.sections?.testimonials ?? false,
+              hero: enabledSections ? enabledSections.has('hero') : c.sections?.hero ?? true,
+              about: enabledSections ? enabledSections.has('about') : c.sections?.about ?? true,
+              experience: enabledSections ? enabledSections.has('experience') : c.sections?.experience ?? true,
+              projects: enabledSections ? enabledSections.has('projects') : c.sections?.projects ?? true,
+              skills: enabledSections ? enabledSections.has('skills') : c.sections?.skills ?? false,
+              education: enabledSections ? enabledSections.has('education') : c.sections?.education ?? false,
+              contact: enabledSections ? enabledSections.has('contact') : c.sections?.contact ?? true,
+              blog: enabledSections ? enabledSections.has('blog') : c.sections?.blog ?? false,
+              testimonials: enabledSections ? enabledSections.has('testimonials') : c.sections?.testimonials ?? false,
             },
             design: {
               creativity: c.design?.creativity ?? 5,
@@ -416,6 +138,7 @@ export default function ConfigPage() {
     if (!files || files.length === 0) return;
 
     setIsUploading(true);
+    setUploadError('');
 
     for (const file of Array.from(files)) {
       const formData = new FormData();
@@ -431,21 +154,34 @@ export default function ConfigPage() {
         if (res.ok) {
           const data = await res.json();
           setUploadedFiles(prev => [...prev, { name: data.name, path: data.path, folder }]);
+        } else {
+          const data = await res.json().catch(() => ({ error: 'Upload failed' }));
+          setUploadError(data.error || 'Upload failed');
         }
       } catch (err) {
         console.error('Upload failed:', err);
+        setUploadError('Upload failed. Check the local server and try again.');
       }
     }
 
     setIsUploading(false);
-    // Reset input
-    if (fileInputRef.current) {
-      fileInputRef.current.value = '';
-    }
+    e.target.value = '';
   };
 
-  const removeUploadedFile = (path: string) => {
-    setUploadedFiles(prev => prev.filter(f => f.path !== path));
+  const removeUploadedFile = async (path: string) => {
+    setUploadError('');
+    const res = await fetch('/api/upload-material', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path }),
+    });
+
+    if (res.ok) {
+      setUploadedFiles(prev => prev.filter(f => f.path !== path));
+    } else {
+      const data = await res.json().catch(() => ({ error: 'Delete failed' }));
+      setUploadError(data.error || 'Delete failed');
+    }
   };
 
   const toggleExample = (url: string) => {
@@ -454,166 +190,8 @@ export default function ConfigPage() {
     );
   };
 
-  // Parse design attributes from text descriptions into structured values
-  const parseDesignAttributes = (design: {
-    typography: string;
-    colors: string;
-    layout: string;
-    spacing: string;
-    motion: string;
-    details: string;
-  }) => {
-    // Extract font family (first font mentioned)
-    const fontMatch = design.typography.match(/([A-Z][a-z]+(?:\s[A-Z][a-z]+)*)/);
-    const fontFamily = fontMatch ? fontMatch[1] : 'Inter';
-
-    // Extract base font size (average if range)
-    const sizeMatch = design.typography.match(/(\d+)(?:-(\d+))?px/);
-    const fontSize = sizeMatch ? (sizeMatch[2] ? Math.round((parseInt(sizeMatch[1]) + parseInt(sizeMatch[2])) / 2) : parseInt(sizeMatch[1])) : 16;
-
-    // Extract font weight
-    const weightMatch = design.typography.match(/(\d{3})\s*weight/);
-    const fontWeight = weightMatch ? parseInt(weightMatch[1]) : 400;
-
-    // Extract letter spacing
-    const trackingMatch = design.typography.match(/([-\d.]+)em\s*tracking/);
-    const letterSpacing = trackingMatch ? trackingMatch[1] + 'em' : 'normal';
-
-    // Extract colors (hex codes)
-    const hexMatches = design.colors.match(/#[0-9A-Fa-f]{3,6}/g) || [];
-    const colorBg = hexMatches[0] || '#000000';
-    const colorText = hexMatches[1] || '#ffffff';
-    const colorAccent = hexMatches[2] || hexMatches[0] || '#5e6ad2';
-
-    // Extract max width
-    const widthMatch = design.layout.match(/(\d+)px/);
-    const maxWidth = widthMatch ? parseInt(widthMatch[1]) : 1200;
-
-    // Extract alignment
-    const alignment = design.layout.toLowerCase().includes('centered') ? 'centered' :
-                     design.layout.toLowerCase().includes('full') ? 'full-width' : 'left';
-
-    // Extract section spacing (average if range)
-    const spacingMatch = design.spacing.match(/(\d+)(?:-(\d+))?px/);
-    const sectionSpacing = spacingMatch ? (spacingMatch[2] ? Math.round((parseInt(spacingMatch[1]) + parseInt(spacingMatch[2])) / 2) : parseInt(spacingMatch[1])) : 100;
-
-    // Extract padding
-    const paddingMatch = design.spacing.match(/(\d+)px\s*padding/);
-    const padding = paddingMatch ? parseInt(paddingMatch[1]) : 40;
-
-    // Extract motion duration
-    const durationMatch = design.motion.match(/(\d+)ms/);
-    const motionDuration = durationMatch ? parseInt(durationMatch[1]) : 200;
-
-    // Extract motion style
-    const motionStyle = design.motion.toLowerCase().includes('fade') ? 'fade' :
-                       design.motion.toLowerCase().includes('slide') ? 'slide' :
-                       design.motion.toLowerCase().includes('snap') ? 'snap' : 'fade';
-
-    // Extract border info
-    const borderMatch = design.details.match(/(\d+)px\s*border/);
-    const borderWidth = design.details.toLowerCase().includes('no border') ? 0 : (borderMatch ? parseInt(borderMatch[1]) : 1);
-
-    // Extract border radius
-    const borderRadius = design.details.toLowerCase().includes('sharp') ||
-                        design.details.toLowerCase().includes('clean edges') ? 0 :
-                        design.details.toLowerCase().includes('rounded') ? 8 : 0;
-
-    return {
-      fontFamily,
-      fontSize,
-      fontWeight,
-      letterSpacing,
-      colorBg,
-      colorText,
-      colorAccent,
-      maxWidth,
-      alignment,
-      sectionSpacing,
-      padding,
-      motionDuration,
-      motionStyle,
-      borderWidth,
-      borderRadius
-    };
-  };
-
-  const generateYaml = () => {
-    // Build design inspirations section with embedded design specs AND parsed attributes
-    const inspirationsText = selectedExamples.length > 0
-      ? `\ndesign_inspirations:${selectedExamples.map(url => {
-          const example = ARCHETYPE_EXAMPLES.flatMap(a => a.examples).find(e => e.url === url);
-          if (!example) return '';
-          const attrs = parseDesignAttributes(example.design);
-          return `
-  - name: "${example.name}"
-    # Extracted attributes (use these programmatically)
-    attributes:
-      fontFamily: "${attrs.fontFamily}"
-      fontSize: ${attrs.fontSize}
-      fontWeight: ${attrs.fontWeight}
-      letterSpacing: "${attrs.letterSpacing}"
-      colorBg: "${attrs.colorBg}"
-      colorText: "${attrs.colorText}"
-      colorAccent: "${attrs.colorAccent}"
-      maxWidth: ${attrs.maxWidth}
-      alignment: "${attrs.alignment}"
-      sectionSpacing: ${attrs.sectionSpacing}
-      padding: ${attrs.padding}
-      motionDuration: ${attrs.motionDuration}
-      motionStyle: "${attrs.motionStyle}"
-      borderWidth: ${attrs.borderWidth}
-      borderRadius: ${attrs.borderRadius}
-    # Original descriptions (for reference)
-    descriptions:
-      typography: "${example.design.typography}"
-      colors: "${example.design.colors}"
-      layout: "${example.design.layout}"
-      spacing: "${example.design.spacing}"
-      motion: "${example.design.motion}"
-      details: "${example.design.details}"`;
-        }).join('')}`
-      : '';
-
-    const enabledSections = Object.entries(config.sections)
-      .filter(([, enabled]) => enabled)
-      .map(([key]) => key);
-
-    return `name: "${config.name || 'Your Name'}"
-email: "${config.email}"
-github: "${config.github}"
-linkedin: "${config.linkedin}"
-twitter: "${config.twitter}"
-website: "${config.website}"
-cli: "${config.cli}"
-
-sections:
-${enabledSections.map(s => `  - ${s}`).join('\n')}
-
-design:
-  creativity: ${config.design.creativity}
-  simplicity: ${config.design.simplicity}
-  playfulness: ${config.design.playfulness}
-  animation: ${config.design.animation}
-  color_intensity: ${config.design.color_intensity}${inspirationsText}
-
-content:
-  tone: "${config.content.tone}"
-  length: "${config.content.length}"
-  focus: "${config.content.focus}"
-
-ai:
-  quality_bar: ${config.ai.quality_bar}
-  research_depth: ${config.ai.research_depth}
-  copy_creativity: ${config.ai.copy_creativity}
-
-notes: |
-${config.notes.split('\n').map((line) => `  ${line}`).join('\n')}
-`;
-  };
-
   const downloadConfig = () => {
-    const yaml = generateYaml();
+    const yaml = generateProfileYaml(config, selectedExamples, ARCHETYPE_EXAMPLES);
     const blob = new Blob([yaml], { type: 'text/yaml' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -623,10 +201,6 @@ ${config.notes.split('\n').map((line) => `  ${line}`).join('\n')}
     URL.revokeObjectURL(url);
     setShowDownloadHelp(true);
   };
-
-  if (process.env.NODE_ENV === 'production') {
-    return null;
-  }
 
   // Loading state
   if (isLoading) {
@@ -643,7 +217,7 @@ ${config.notes.split('\n').map((line) => `  ${line}`).join('\n')}
   const steps = [
     { id: 'basics' as const, label: 'Basics', description: 'Name & contact info' },
     { id: 'design' as const, label: 'Design', description: 'Style & inspirations' },
-    { id: 'review' as const, label: 'Review', description: 'Save & generate' },
+    { id: 'review' as const, label: 'Review', description: 'Save your profile' },
   ];
 
   const currentStepIndex = steps.findIndex(s => s.id === currentStep);
@@ -671,7 +245,7 @@ ${config.notes.split('\n').map((line) => `  ${line}`).join('\n')}
                 <span className="font-semibold">Next Step</span>
               </div>
               <p className="text-neutral-400 text-sm mb-4">
-                Close this tab and return to your terminal. The AI will automatically start building your portfolio.
+                Close this tab and return to your terminal. The setup script will ask which AI tool you want to launch.
               </p>
             </div>
 
@@ -769,7 +343,7 @@ ${config.notes.split('\n').map((line) => `  ${line}`).join('\n')}
             <div className="flex items-center gap-3">
               <Check size={20} />
               <span className="font-medium">Config saved!</span>
-              <span className="text-green-100">Return to your terminal and press <kbd className="bg-green-700 px-2 py-0.5 rounded text-xs font-mono">Ctrl+C</kbd> to continue.</span>
+              <span className="text-green-100">Return to your terminal. The setup script will continue.</span>
             </div>
             <button
               onClick={() => setConfigSaved(false)}
@@ -792,7 +366,7 @@ ${config.notes.split('\n').map((line) => `  ${line}`).join('\n')}
                   <h2 className="font-bold text-lg mb-2">Let&apos;s start with the basics</h2>
                   <p className="text-neutral-400 text-sm leading-relaxed">
                     Only your <span className="text-white font-medium">name</span> is required.
-                    The AI will research and fill in everything else.
+                    Your coding agent can ask before researching any missing details.
                   </p>
                 </div>
               </div>
@@ -868,6 +442,8 @@ ${config.notes.split('\n').map((line) => `  ${line}`).join('\n')}
                     <option value="gemini">Google Gemini CLI</option>
                     <option value="aider">Aider</option>
                     <option value="cursor">Cursor AI</option>
+                    <option value="windsurf">Windsurf</option>
+                    <option value="antigravity">Antigravity</option>
                     <option value="other">Other / Custom</option>
                   </select>
                   <p className="text-xs text-neutral-500 mt-1.5">Which AI coding assistant will build your portfolio?</p>
@@ -973,7 +549,7 @@ ${config.notes.split('\n').map((line) => `  ${line}`).join('\n')}
                 Materials
               </h2>
               <p className="text-neutral-400 text-sm mb-4">
-                Upload resumes, headshots, or other files for the AI to use.
+                Add local files for your coding agent to use. Maximum 10 MB each. Review them before pushing to a public repository.
               </p>
 
               <div className="space-y-3">
@@ -999,7 +575,7 @@ ${config.notes.split('\n').map((line) => `  ${line}`).join('\n')}
                 {/* Images upload */}
                 <label className="flex items-center gap-3 p-4 bg-neutral-900 border border-neutral-800 rounded-lg cursor-pointer hover:border-neutral-600 transition-colors">
                   <div className="w-10 h-10 bg-neutral-800 rounded-lg flex items-center justify-center">
-                    <Image size={20} className="text-neutral-400" />
+                    <ImageIcon size={20} className="text-neutral-400" />
                   </div>
                   <div className="flex-1">
                     <div className="font-medium text-sm">Upload Images</div>
@@ -1009,7 +585,7 @@ ${config.notes.split('\n').map((line) => `  ${line}`).join('\n')}
                   <input
                     type="file"
                     className="hidden"
-                    accept=".jpg,.jpeg,.png,.webp,.gif,.svg"
+                    accept=".jpg,.jpeg,.png,.webp,.gif"
                     multiple
                     onChange={(e) => handleFileUpload(e, 'images')}
                   />
@@ -1022,6 +598,12 @@ ${config.notes.split('\n').map((line) => `  ${line}`).join('\n')}
                   <div className="w-4 h-4 border-2 border-neutral-600 border-t-white rounded-full animate-spin" />
                   Uploading...
                 </div>
+              )}
+
+              {uploadError && (
+                <p className="mt-3 text-sm text-red-400" role="alert">
+                  {uploadError}
+                </p>
               )}
 
               {/* Uploaded files list */}
@@ -1038,6 +620,8 @@ ${config.notes.split('\n').map((line) => `  ${line}`).join('\n')}
                       <span className="text-xs text-neutral-600">{file.folder}</span>
                       <button
                         onClick={() => removeUploadedFile(file.path)}
+                        type="button"
+                        aria-label={`Delete ${file.name}`}
                         className="p-1 hover:bg-neutral-800 rounded transition-colors"
                       >
                         <X size={14} className="text-neutral-500" />
@@ -1120,10 +704,11 @@ ${config.notes.split('\n').map((line) => `  ${line}`).join('\n')}
                             : 'border-neutral-800 hover:border-neutral-600'
                         }`}
                       >
-                        {/* eslint-disable-next-line @next/next/no-img-element */}
-                        <img
+                        <Image
                           src={example.screenshot}
                           alt={example.name}
+                          fill
+                          sizes="(max-width: 768px) 33vw, 300px"
                           className="w-full h-full object-cover object-top"
                           loading="lazy"
                           onError={(e) => {
@@ -1323,13 +908,17 @@ ${config.notes.split('\n').map((line) => `  ${line}`).join('\n')}
               <p className="text-neutral-400 mb-6">
                 {hasExistingConfig
                   ? 'Your changes will be saved to profile.yaml'
-                  : 'Save your config and the AI will start building your portfolio'}
+                  : 'Save your profile, then return to the setup script to choose your coding agent'}
               </p>
 
           {/* Primary action - Save to Project */}
           <button
             onClick={async () => {
-              const yaml = generateYaml();
+              if (!config.name.trim()) {
+                setCurrentStep('basics');
+                return;
+              }
+                  const yaml = generateProfileYaml(config, selectedExamples, ARCHETYPE_EXAMPLES);
               try {
                 const res = await fetch('/api/save-config', {
                   method: 'POST',
@@ -1345,7 +934,8 @@ ${config.notes.split('\n').map((line) => `  ${line}`).join('\n')}
                 alert('Failed to save. Try Download instead.');
               }
             }}
-            className="bg-green-600 text-white px-8 py-4 rounded-lg hover:bg-green-700 transition-colors font-semibold text-lg flex items-center gap-3 mx-auto"
+            disabled={!config.name.trim()}
+            className="bg-green-600 text-white px-8 py-4 rounded-lg hover:bg-green-700 disabled:cursor-not-allowed disabled:opacity-50 transition-colors font-semibold text-lg flex items-center gap-3 mx-auto"
           >
             <Check size={24} />
             Save to Project

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,8 +9,8 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
-  title: "Portfolio",
-  description: "Personal portfolio",
+  title: "Persona — A portfolio starter kit for coding agents",
+  description: "Build a personal portfolio that feels designed around you, not filled into a template.",
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,46 +1,63 @@
 import Link from "next/link";
 
+const steps = [
+  ["01", "Share your story", "Add your goals, links, work, and visual taste locally."],
+  ["02", "Choose a direction", "Your coding agent researches and presents a design before building."],
+  ["03", "Make it yours", "The agent builds, checks, and helps publish a portfolio unique to you."],
+];
+
 export default function Home() {
+  const isDevelopment = process.env.NODE_ENV === "development";
+
   return (
-    <main className="min-h-screen flex items-center justify-center px-6">
-      <div className="max-w-lg w-full text-center">
-        <div className="mb-8">
-          <svg
-            width="64"
-            height="64"
-            viewBox="0 0 64 64"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            className="mx-auto"
-          >
-            <rect width="64" height="64" rx="14" fill="white" />
-            <path
-              d="M20 48V16H32C35.1826 16 38.2348 17.2643 40.4853 19.5147C42.7357 21.7652 44 24.8174 44 28C44 31.1826 42.7357 34.2348 40.4853 36.4853C38.2348 38.7357 35.1826 40 32 40H28V48H20ZM28 32H32C33.0609 32 34.0783 31.5786 34.8284 30.8284C35.5786 30.0783 36 29.0609 36 28C36 26.9391 35.5786 25.9217 34.8284 25.1716C34.0783 24.4214 33.0609 24 32 24H28V32Z"
-              fill="black"
-            />
-          </svg>
-        </div>
+    <main className="min-h-screen px-6 py-10 sm:px-10 lg:px-16">
+      <div className="mx-auto flex min-h-[calc(100vh-5rem)] max-w-6xl flex-col">
+        <header className="flex items-center justify-between border-b border-neutral-800 pb-5">
+          <div className="flex items-center gap-3">
+            <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-white font-semibold text-black">
+              P
+            </span>
+            <span className="font-medium">Persona</span>
+          </div>
+          <span className="hidden text-xs uppercase tracking-[0.2em] text-neutral-500 sm:block">Portfolio starter kit</span>
+        </header>
 
-        <h1 className="text-3xl font-medium mb-4">Persona</h1>
+        <section className="grid flex-1 items-center gap-14 py-16 lg:grid-cols-[1.25fr_0.75fr] lg:py-24">
+          <div>
+            <p className="mb-5 text-sm text-neutral-500">For people with more personality than a template</p>
+            <h1 className="max-w-4xl text-5xl font-medium leading-[0.98] tracking-[-0.05em] sm:text-7xl">
+              Build a portfolio that feels like you.
+            </h1>
+            <p className="mt-7 max-w-2xl text-lg leading-8 text-neutral-400">
+              Persona gives your coding agent the context and guardrails to design a personal site—not paste your name into the same developer portfolio everyone has.
+            </p>
 
-        <p className="text-neutral-400 mb-8 leading-relaxed">
-          Your portfolio will appear here once built.
-          <br />
-          Run the setup script to get started.
-        </p>
+            <div className="mt-9 flex flex-col gap-3 sm:flex-row">
+              <Link
+                href={isDevelopment ? "/config" : "https://github.com/new?template_name=persona&template_owner=JacbK"}
+                className="rounded-lg bg-white px-5 py-3 text-center text-sm font-medium text-black transition-colors hover:bg-neutral-200"
+              >
+                {isDevelopment ? "Open local setup" : "Use this template"}
+              </Link>
+              <code className="rounded-lg border border-neutral-800 bg-neutral-900 px-5 py-3 text-center text-sm text-neutral-300">
+                ./setup.sh
+              </code>
+            </div>
+            <p className="mt-4 text-xs text-neutral-600">Your profile and materials stay in your local repository.</p>
+          </div>
 
-        <div className="bg-neutral-900 border border-neutral-800 rounded-lg p-4 mb-8 text-left">
-          <code className="text-sm text-neutral-300 font-mono">
-            ./bin/setup.sh
-          </code>
-        </div>
-
-        <Link
-          href="/config"
-          className="inline-block text-sm text-neutral-500 hover:text-neutral-300 transition-colors"
-        >
-          Or configure manually &rarr;
-        </Link>
+          <ol className="divide-y divide-neutral-800 border-y border-neutral-800">
+            {steps.map(([number, title, description]) => (
+              <li key={number} className="grid grid-cols-[2.5rem_1fr] gap-4 py-6">
+                <span className="font-mono text-xs text-neutral-600">{number}</span>
+                <div>
+                  <h2 className="font-medium">{title}</h2>
+                  <p className="mt-2 text-sm leading-6 text-neutral-500">{description}</p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </section>
       </div>
     </main>
   );

--- a/src/lib/local-setup.test.ts
+++ b/src/lib/local-setup.test.ts
@@ -1,0 +1,26 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it } from "vitest";
+import { isLocalSetupRequest } from "./local-setup";
+
+describe("isLocalSetupRequest", () => {
+  it("allows same-origin localhost requests outside production", () => {
+    const request = new NextRequest("http://127.0.0.1:3000/api/read-config", {
+      headers: { origin: "http://127.0.0.1:3000" },
+    });
+    expect(isLocalSetupRequest(request, "development")).toBe(true);
+  });
+
+  it("rejects remote hosts and cross-origin requests", () => {
+    const remote = new NextRequest("https://portfolio.example/api/read-config");
+    const crossOrigin = new NextRequest("http://127.0.0.1:3000/api/read-config", {
+      headers: { origin: "https://evil.example" },
+    });
+    expect(isLocalSetupRequest(remote, "development")).toBe(false);
+    expect(isLocalSetupRequest(crossOrigin, "development")).toBe(false);
+  });
+
+  it("rejects every request in production", () => {
+    const request = new NextRequest("http://127.0.0.1:3000/api/read-config");
+    expect(isLocalSetupRequest(request, "production")).toBe(false);
+  });
+});

--- a/src/lib/local-setup.ts
+++ b/src/lib/local-setup.ts
@@ -1,0 +1,31 @@
+import type { NextRequest } from "next/server";
+
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+
+export function isLocalSetupRequest(
+  request: NextRequest,
+  environment = process.env.NODE_ENV,
+): boolean {
+  if (environment === "production") return false;
+
+  const requestUrl = new URL(request.url);
+  if (!LOCAL_HOSTS.has(requestUrl.hostname)) return false;
+
+  const origin = request.headers.get("origin");
+  if (!origin) return true;
+
+  try {
+    const originUrl = new URL(origin);
+    return (
+      LOCAL_HOSTS.has(originUrl.hostname) &&
+      originUrl.protocol === requestUrl.protocol &&
+      originUrl.port === requestUrl.port
+    );
+  } catch {
+    return false;
+  }
+}
+
+export const LOCAL_ONLY_RESPONSE = {
+  error: "This setup endpoint is only available from the local development server.",
+};

--- a/src/lib/material-upload.test.ts
+++ b/src/lib/material-upload.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_UPLOAD_BYTES,
+  sanitizeMaterialName,
+  validateMaterialUpload,
+} from "./material-upload";
+
+describe("sanitizeMaterialName", () => {
+  it("removes directories and unsafe characters", () => {
+    expect(sanitizeMaterialName("../My Resume (final).pdf")).toBe("My_Resume__final_.pdf");
+  });
+
+  it("rejects empty path names", () => {
+    expect(() => sanitizeMaterialName("..")).toThrow("Invalid filename");
+  });
+});
+
+describe("validateMaterialUpload", () => {
+  it("accepts an allowed document", () => {
+    const file = new File(["resume"], "resume.pdf", { type: "application/pdf" });
+    expect(validateMaterialUpload(file, "documents")).toBe("resume.pdf");
+  });
+
+  it("rejects executable and SVG uploads", () => {
+    const executable = new File(["bad"], "resume.js");
+    const svg = new File(["<svg />"], "portrait.svg", { type: "image/svg+xml" });
+    expect(() => validateMaterialUpload(executable, "documents")).toThrow();
+    expect(() => validateMaterialUpload(svg, "images")).toThrow();
+  });
+
+  it("rejects oversized files", () => {
+    const file = { name: "resume.pdf", size: MAX_UPLOAD_BYTES + 1 } as File;
+    expect(() => validateMaterialUpload(file, "documents")).toThrow("10 MB");
+  });
+});

--- a/src/lib/material-upload.ts
+++ b/src/lib/material-upload.ts
@@ -1,0 +1,32 @@
+import { basename, extname } from "path";
+
+export const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+
+const ALLOWED_EXTENSIONS = {
+  documents: new Set([".pdf", ".txt", ".md", ".doc", ".docx"]),
+  images: new Set([".jpg", ".jpeg", ".png", ".webp", ".gif"]),
+} as const;
+
+export type MaterialFolder = keyof typeof ALLOWED_EXTENSIONS;
+
+export function sanitizeMaterialName(name: string): string {
+  const clean = basename(name).replace(/[^a-zA-Z0-9._-]/g, "_");
+  if (!clean || clean === "." || clean === "..") {
+    throw new Error("Invalid filename");
+  }
+  return clean;
+}
+
+export function validateMaterialUpload(file: File, folder: MaterialFolder): string {
+  if (file.size <= 0 || file.size > MAX_UPLOAD_BYTES) {
+    throw new Error("Files must be between 1 byte and 10 MB");
+  }
+
+  const safeName = sanitizeMaterialName(file.name);
+  const extension = extname(safeName).toLowerCase();
+  if (!ALLOWED_EXTENSIONS[folder].has(extension)) {
+    throw new Error(`Unsupported ${folder} file type`);
+  }
+
+  return safeName;
+}

--- a/src/lib/profile-config.test.ts
+++ b/src/lib/profile-config.test.ts
@@ -1,0 +1,88 @@
+import * as yaml from "js-yaml";
+import { describe, expect, it } from "vitest";
+import {
+  generateProfileYaml,
+  parseDesignAttributes,
+  type InspirationArchetype,
+  type ProfileConfig,
+} from "./profile-config";
+
+const config: ProfileConfig = {
+  name: 'Ava "AJ" Jones',
+  email: "ava@example.com",
+  github: "https://github.com/ava",
+  linkedin: "",
+  twitter: "",
+  website: "",
+  cli: "codex",
+  sections: { hero: true, projects: true, blog: false },
+  design: {
+    creativity: 7,
+    simplicity: 8,
+    playfulness: 4,
+    animation: 3,
+    color_intensity: 5,
+    notes: "",
+  },
+  content: { tone: "conversational", length: "concise", focus: "projects" },
+  ai: { quality_bar: 8, research_depth: 6, copy_creativity: 5 },
+  notes: "First line\nSecond: line",
+};
+
+const archetypes: InspirationArchetype[] = [
+  {
+    id: 1,
+    name: "Minimal",
+    description: "Quiet",
+    color: "from-black to-white",
+    examples: [
+      {
+        name: "Example",
+        url: "https://example.com",
+        screenshot: "/example.png",
+        design: {
+          typography: "Inter, 14-18px, 500 weight",
+          colors: "Black #000000, white #ffffff, blue #5e6ad2",
+          layout: "Centered, 1200px max",
+          spacing: "80-120px, 40px padding",
+          motion: "Subtle fades, 200ms",
+          details: "1px border, rounded cards",
+        },
+      },
+    ],
+  },
+];
+
+describe("generateProfileYaml", () => {
+  it("round-trips user text and enabled sections safely", () => {
+    const output = generateProfileYaml(config, [], archetypes);
+    const parsed = yaml.load(output) as Record<string, unknown>;
+
+    expect(parsed.name).toBe(config.name);
+    expect(parsed.notes).toBe(config.notes);
+    expect(parsed.sections).toEqual(["hero", "projects"]);
+  });
+
+  it("includes only selected design inspirations", () => {
+    const output = generateProfileYaml(config, ["https://example.com"], archetypes);
+    const parsed = yaml.load(output) as { design_inspirations: Array<{ name: string }> };
+
+    expect(parsed.design_inspirations).toEqual([
+      expect.objectContaining({ name: "Example" }),
+    ]);
+  });
+});
+
+describe("parseDesignAttributes", () => {
+  it("turns design descriptions into stable values", () => {
+    expect(parseDesignAttributes(archetypes[0].examples[0].design)).toEqual(
+      expect.objectContaining({
+        fontFamily: "Inter",
+        fontSize: 16,
+        fontWeight: 500,
+        maxWidth: 1200,
+        sectionSpacing: 100,
+      }),
+    );
+  });
+});

--- a/src/lib/profile-config.ts
+++ b/src/lib/profile-config.ts
@@ -1,0 +1,157 @@
+import * as yaml from "js-yaml";
+
+export type DesignDescription = {
+  typography: string;
+  colors: string;
+  layout: string;
+  spacing: string;
+  motion: string;
+  details: string;
+};
+
+type InspirationExample = {
+  name: string;
+  url: string;
+  screenshot: string;
+  design: DesignDescription;
+};
+
+export type InspirationArchetype = {
+  id: number;
+  name: string;
+  description: string;
+  color: string;
+  examples: InspirationExample[];
+};
+
+export type ProfileConfig = {
+  name: string;
+  email: string;
+  github: string;
+  linkedin: string;
+  twitter: string;
+  website: string;
+  cli: string;
+  sections: Record<string, boolean>;
+  design: {
+    creativity: number;
+    simplicity: number;
+    playfulness: number;
+    animation: number;
+    color_intensity: number;
+    notes: string;
+  };
+  content: {
+    tone: string;
+    length: string;
+    focus: string;
+  };
+  ai: {
+    quality_bar: number;
+    research_depth: number;
+    copy_creativity: number;
+  };
+  notes: string;
+};
+
+export function parseDesignAttributes(design: DesignDescription) {
+  const fontMatch = design.typography.match(/([A-Z][a-z]+(?:\s[A-Z][a-z]+)*)/);
+  const sizeMatch = design.typography.match(/(\d+)(?:-(\d+))?px/);
+  const weightMatch = design.typography.match(/(\d{3})\s*weight/);
+  const trackingMatch = design.typography.match(/([-\d.]+)em\s*tracking/);
+  const hexMatches = design.colors.match(/#[0-9A-Fa-f]{3,6}/g) ?? [];
+  const widthMatch = design.layout.match(/(\d+)px/);
+  const spacingMatch = design.spacing.match(/(\d+)(?:-(\d+))?px/);
+  const paddingMatch = design.spacing.match(/(\d+)px\s*padding/);
+  const durationMatch = design.motion.match(/(\d+)ms/);
+  const borderMatch = design.details.match(/(\d+)px\s*border/);
+
+  return {
+    fontFamily: fontMatch?.[1] ?? "Inter",
+    fontSize: sizeMatch
+      ? sizeMatch[2]
+        ? Math.round((Number(sizeMatch[1]) + Number(sizeMatch[2])) / 2)
+        : Number(sizeMatch[1])
+      : 16,
+    fontWeight: weightMatch ? Number(weightMatch[1]) : 400,
+    letterSpacing: trackingMatch ? `${trackingMatch[1]}em` : "normal",
+    colorBg: hexMatches[0] ?? "#000000",
+    colorText: hexMatches[1] ?? "#ffffff",
+    colorAccent: hexMatches[2] ?? hexMatches[0] ?? "#5e6ad2",
+    maxWidth: widthMatch ? Number(widthMatch[1]) : 1200,
+    alignment: design.layout.toLowerCase().includes("centered")
+      ? "centered"
+      : design.layout.toLowerCase().includes("full")
+        ? "full-width"
+        : "left",
+    sectionSpacing: spacingMatch
+      ? spacingMatch[2]
+        ? Math.round((Number(spacingMatch[1]) + Number(spacingMatch[2])) / 2)
+        : Number(spacingMatch[1])
+      : 100,
+    padding: paddingMatch ? Number(paddingMatch[1]) : 40,
+    motionDuration: durationMatch ? Number(durationMatch[1]) : 200,
+    motionStyle: design.motion.toLowerCase().includes("slide")
+      ? "slide"
+      : design.motion.toLowerCase().includes("snap")
+        ? "snap"
+        : "fade",
+    borderWidth: design.details.toLowerCase().includes("no border")
+      ? 0
+      : borderMatch
+        ? Number(borderMatch[1])
+        : 1,
+    borderRadius:
+      design.details.toLowerCase().includes("sharp") ||
+      design.details.toLowerCase().includes("clean edges")
+        ? 0
+        : design.details.toLowerCase().includes("rounded")
+          ? 8
+          : 0,
+  };
+}
+
+export function generateProfileYaml(
+  config: ProfileConfig,
+  selectedExamples: string[],
+  archetypes: InspirationArchetype[],
+): string {
+  const examples = archetypes.flatMap((archetype) => archetype.examples);
+  const designInspirations = selectedExamples.flatMap((url) => {
+    const example = examples.find((item) => item.url === url);
+    if (!example) return [];
+    return [
+      {
+        name: example.name,
+        url: example.url,
+        attributes: parseDesignAttributes(example.design),
+        descriptions: example.design,
+      },
+    ];
+  });
+
+  const output = {
+    name: config.name || "Your Name",
+    email: config.email,
+    github: config.github,
+    linkedin: config.linkedin,
+    twitter: config.twitter,
+    website: config.website,
+    cli: config.cli,
+    sections: Object.entries(config.sections)
+      .filter(([, enabled]) => enabled)
+      .map(([section]) => section),
+    design: config.design,
+    ...(designInspirations.length > 0
+      ? { design_inspirations: designInspirations }
+      : {}),
+    content: config.content,
+    ai: config.ai,
+    notes: config.notes,
+  };
+
+  return yaml.dump(output, {
+    noRefs: true,
+    lineWidth: 100,
+  });
+}


### PR DESCRIPTION
## What changed

- Rewrote the project page, README, materials copy, setup guidance, and deployment skill.
- Replaced the old setup script with a smaller local-only flow that does not collect tokens or edit global agent settings.
- Upgraded the compatible Next.js, React, and tooling stack and removed unused packages.
- Locked config and upload routes to local development, added YAML validation, upload limits and type checks, and real file deletion.
- Split config data and logic into focused modules and added 11 tests.
- Added CI, Dependabot, manual and gated deployments, and an MIT license.

## Why

The starter kit had stale requirements and model copy, failing automatic deployment workflows, no tests, 11 dependency vulnerabilities, and production-accessible setup APIs. The onboarding also made stronger promises than the actual setup flow.

## Impact

New users get clearer setup instructions, safer local handling of personal materials, predictable manual deployments, and a starter kit that can keep itself current. Existing portfolio output remains compatible with the same profile fields.

## Validation

- `npm run check`
- `npm run audit` — 0 vulnerabilities
- 11 Vitest tests
- Normal Next.js production build
- GitHub Pages static-export build
- Production smoke: homepage 200; config/write/delete routes 404
- Desktop and mobile browser verification with no console errors or horizontal overflow
